### PR TITLE
Commit hash as version but not in git

### DIFF
--- a/lib/mrsk/commander.rb
+++ b/lib/mrsk/commander.rb
@@ -91,7 +91,15 @@ class Mrsk::Commander
 
   private
     def cascading_version
-      version.presence || ENV["VERSION"] || `git rev-parse HEAD`.strip
+      version.presence || ENV["VERSION"] || current_commit_hash
+    end
+
+    def current_commit_hash
+      if system("git rev-parse")
+        `git rev-parse HEAD`.strip
+      else
+        raise "Can't use commit hash as version, no git repository found in #{Dir.pwd}"
+      end
     end
 
     # Lazy setup of SSHKit

--- a/test/commander_test.rb
+++ b/test/commander_test.rb
@@ -9,6 +9,16 @@ class CommanderTest < ActiveSupport::TestCase
     assert_equal Mrsk::Configuration, @mrsk.config.class
   end
 
+  test "commit hash as version" do
+    assert_equal `git rev-parse HEAD`.strip, @mrsk.config.version
+  end
+
+  test "commit hash as version but not in git" do
+    @mrsk.expects(:system).with("git rev-parse").returns(nil)
+    error = assert_raises(RuntimeError) { @mrsk.config }
+    assert_match /no git repository found/, error.message
+  end
+
   test "overwriting hosts" do
     assert_equal [ "1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4" ], @mrsk.hosts
 


### PR DESCRIPTION
Displays a more concise error if the application isn't yet inside a git repository.

Addresses #11 