### PR TITLE
Set .env files to 0600 so they're not world-readable

### DIFF
--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -107,13 +107,9 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
   desc "envify", "Create .env by evaluating .env.erb (or .env.staging.erb -> .env.staging when using -d staging)"
   def envify
     if destination = options[:destination]
-      File.write(".env.#{destination}", "")
-      File.chown(0600, ".env.#{destination}")
-      File.write(".env.#{destination}", ERB.new(IO.read(Pathname.new(File.expand_path(".env.#{destination}.erb")))).result)
+      File.write(".env.#{destination}", ERB.new(IO.read(Pathname.new(File.expand_path(".env.#{destination}.erb")))).result, perm: 0600)
     else
-      File.write(".env", "")
-      File.chown(0600, ".env")
-      File.write(".env", ERB.new(IO.read(Pathname.new(File.expand_path(".env.erb")))).result)
+      File.write(".env", ERB.new(IO.read(Pathname.new(File.expand_path(".env.erb")))).result, perm: 0600)
     end
   end
 

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -107,8 +107,12 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
   desc "envify", "Create .env by evaluating .env.erb (or .env.staging.erb -> .env.staging when using -d staging)"
   def envify
     if destination = options[:destination]
+      File.write(".env.#{destination}", "")
+      File.chown(0600, ".env.#{destination}")
       File.write(".env.#{destination}", ERB.new(IO.read(Pathname.new(File.expand_path(".env.#{destination}.erb")))).result)
     else
+      File.write(".env", "")
+      File.chown(0600, ".env")
       File.write(".env", ERB.new(IO.read(Pathname.new(File.expand_path(".env.erb")))).result)
     end
   end


### PR DESCRIPTION
If we don't want to keep the 'generate credentials' step inside the mrsk execution paths, let's be careful with the credentials we do pull down, and not world-readable.

I'm intentionally touching the file first and setting permissions, so that credentials are never in a world-readable file, but the actual chance of that happening is extremely minimal, in which case, the `File.chown` call could be moved after the `File.write`.