### PR TITLE
Adjust CLI description for prune command to mention 7 days

### DIFF
--- a/lib/mrsk/cli/prune.rb
+++ b/lib/mrsk/cli/prune.rb
@@ -5,7 +5,7 @@ class Mrsk::Cli::Prune < Mrsk::Cli::Base
     invoke :images
   end
 
-  desc "images", "Prune unused images older than 30 days"
+  desc "images", "Prune unused images older than 7 days"
   def images
     on(MRSK.hosts) do
       execute *MRSK.auditor.record("prune images"), verbosity: :debug


### PR DESCRIPTION
Images are pruned after 7 days now instead of 30. https://github.com/mrsked/mrsk/commit/9eaf0f3b8fa86b16613a4e9a1733c95ff7b138bd