### PR TITLE
fix(docker-run): Docker run environment variables concatenation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gemspec
 gem "debug"
 gem "mocha"
 gem "railties"
+gem "ed25519"
+gem "bcrypt_pbkdf"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    bcrypt_pbkdf (1.1.0)
     builder (3.2.4)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
@@ -36,6 +37,7 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     dotenv (2.8.1)
+    ed25519 (1.3.0)
     erubi (1.12.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -96,7 +98,9 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt_pbkdf
   debug
+  ed25519
   mocha
   mrsk!
   railties

--- a/lib/mrsk/utils.rb
+++ b/lib/mrsk/utils.rb
@@ -5,7 +5,7 @@ module Mrsk::Utils
   def argumentize(argument, attributes, redacted: false)
     Array(attributes).flat_map do |k, v|
       if v.present?
-        [ argument, redacted ? redact("#{k}=#{v}") : "#{k}=#{v}" ]
+        [ argument, redacted ? redact("#{k}=\"#{v}\"") : "#{k}=\"#{v}\"" ]
       else
         [ argument, k ]
       end


### PR DESCRIPTION
After trying out a symfony app with a PostgreSQL accessory db, I realized this environment variable string (from `.env`) was creating a docker run error : 
```
DATABASE_URL="postgresql://hello:hello@51.75.243.60:5432/hello?serverVersion=15&charset=utf8"
```
The `&` character is indeed currently not escaped properly, creating a docker run command that looks like this and errors: 
```
  INFO [6e8b7c54] Running docker run -d --restart unless-stopped --log-opt max-size=10m --name hello-symfo-5d3fefad8a96de47e74614dde142f540f0b33066 -e DATABASE_URL=postgresql://hello:hello@127.0.0.1:5432/hello?serverVersion=15&charset=utf8 -e APP_ENV=production --label service=hello-symfo --label role=web --label traefik.http.routers.hello-symfo.rule='PathPrefix(`/`)' --label traefik.http.services.hello-symfo.loadbalancer.healthcheck.path=/up --label traefik.http.services.hello-symfo.loadbalancer.healthcheck.interval=1s --label traefik.http.middlewares.hello-symfo.retry.attempts=3 --label traefik.http.middlewares.hello-symfo.retry.initialinterval=500ms docker.io/pauulog/hello-symfo:5d3fefad8a96de47e74614dde142f540f0b33066 on 1.1.1.1
  Finished all in 29.5 seconds
  ERROR (SSHKit::Command::Failed): docker exit status: 127
docker stdout: Nothing written
docker stderr: bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
bash: line 1: -e: command not found
"docker run" requires at least 1 argument.
See 'docker run --help'.

Usage:  docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

Run a command in a new container
```

I believe the proposed fix ensures environment variables are properly quoted and special characters escaped in all cases.

Also, this PR adds ed25519 SSH keys support 