### PR TITLE
docs(traefik-labels): Improve docs for traefik labels formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ You can specialize the default Traefik rules by setting labels on the containers
 
 ```
 labels:
-  traefik.http.routers.hey.rule: '''Host(`app.hey.com`)'''
+  traefik.http.routers.hey.rule: Host(\`app.hey.com\`)
 ```
 
-Note: The extra quotes are needed to ensure the rule is passed in correctly!
+Note: The escaped backticks are needed to ensure the rule is passed in correctly and not treated as command substitution by Bash!
 
 This allows you to run multiple applications on the same server sharing the same Traefik instance and port.
 See https://doc.traefik.io/traefik/routing/routers/#rule for a full list of available routing rules.


### PR DESCRIPTION
The former syntax does not create a valid label, because the label is not properly escaped in the docker run command, but command substitution happens, yielding this result : 
```bash
docker run -d --restart unless-stopped --log-opt max-size=10m --name hello-symfo-5d3fefad8a96de47e74614dde142f540f0b33066  --label traefik.http.routers.hello-symfo.rule='PathPrefix(`/`)' symfo:5d3fefad8a96de47e74614dde142f540f0b33066
```
Which in turn gives us this label and this error in traefik container logs : 
```json
"Labels": {
    "role": "web",
    "service": "hello-symfo",
    "traefik.http.middlewares.hello-symfo.retry.attempts": "3",
    "traefik.http.middlewares.hello-symfo.retry.initialinterval": "500ms",
    "traefik.http.routers.hello-symfo.rule": "'PathPrefix()'",
    "traefik.http.services.hello-symfo.loadbalancer.healthcheck.interval": "1s",
    "traefik.http.services.hello-symfo.loadbalancer.healthcheck.path": "/up"
},
```
```bash
time="2023-02-17T22:49:23Z" level=error msg="error while parsing rule 'PathPrefix()': 1:1: illegal rune literal" entryPointName=http routerName=hello-symfo@docker
```

I also believe this error plagues the default labels created by mrsk but didn't know how to fix it.