### PR TITLE
fix(escape-cli-args): Always use quotes to escape CLI arguments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gemspec
 gem "debug"
 gem "mocha"
 gem "railties"
+gem "ed25519"
+gem "bcrypt_pbkdf"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    bcrypt_pbkdf (1.1.0)
     builder (3.2.4)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
@@ -36,6 +37,7 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     dotenv (2.8.1)
+    ed25519 (1.3.0)
     erubi (1.12.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -96,7 +98,9 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt_pbkdf
   debug
+  ed25519
   mocha
   mrsk!
   railties

--- a/lib/mrsk/configuration/role.rb
+++ b/lib/mrsk/configuration/role.rb
@@ -58,7 +58,7 @@ class Mrsk::Configuration::Role
     def traefik_labels
       if running_traefik?
         {
-          "traefik.http.routers.#{config.service}.rule" => 'PathPrefix(\`/\`)',
+          "traefik.http.routers.#{config.service}.rule" => "PathPrefix(`/`)",
           "traefik.http.services.#{config.service}.loadbalancer.healthcheck.path" => config.healthcheck["path"],
           "traefik.http.services.#{config.service}.loadbalancer.healthcheck.interval" => "1s",
           "traefik.http.middlewares.#{config.service}.retry.attempts" => "3",

--- a/lib/mrsk/configuration/role.rb
+++ b/lib/mrsk/configuration/role.rb
@@ -58,7 +58,7 @@ class Mrsk::Configuration::Role
     def traefik_labels
       if running_traefik?
         {
-          "traefik.http.routers.#{config.service}.rule" => "'PathPrefix(`/`)'",
+          "traefik.http.routers.#{config.service}.rule" => 'PathPrefix(\`/\`)',
           "traefik.http.services.#{config.service}.loadbalancer.healthcheck.path" => config.healthcheck["path"],
           "traefik.http.services.#{config.service}.loadbalancer.healthcheck.interval" => "1s",
           "traefik.http.middlewares.#{config.service}.retry.attempts" => "3",

--- a/lib/mrsk/utils.rb
+++ b/lib/mrsk/utils.rb
@@ -1,13 +1,14 @@
 module Mrsk::Utils
   extend self
 
-  # Return a list of shell arguments using the same named argument against the passed attributes (hash or array).
+  # Return a list of escaped shell arguments using the same named argument against the passed attributes (hash or array).
   def argumentize(argument, attributes, redacted: false)
-    Array(attributes).flat_map do |k, v|
-      if v.present?
-        [ argument, redacted ? redact("#{k}=#{escape_bash_string v.to_s}") : "#{k}=#{escape_bash_string v.to_s}" ]
+    Array(attributes).flat_map do |key, value|
+      if value.present?
+        escaped_pair = [ key, value.to_s.dump.gsub(/`/, '\\\\`') ].join("=")
+        [ argument, redacted ? redact(escaped_pair) : escaped_pair ]
       else
-        [ argument, k ]
+        [ argument, key ]
       end
     end
   end
@@ -25,9 +26,5 @@ module Mrsk::Utils
   # Copied from SSHKit::Backend::Abstract#redact to be available inside Commands classes
   def redact(arg) # Used in execute_command to hide redact() args a user passes in
     arg.to_s.extend(SSHKit::Redaction) # to_s due to our inability to extend Integer, etc
-  end
-
-  def escape_bash_string(string)
-    string.dump.gsub(/`/, '\\\\`')
   end
 end

--- a/lib/mrsk/utils.rb
+++ b/lib/mrsk/utils.rb
@@ -5,7 +5,7 @@ module Mrsk::Utils
   def argumentize(argument, attributes, redacted: false)
     Array(attributes).flat_map do |k, v|
       if v.present?
-        [ argument, redacted ? redact("#{k}=\"#{v}\"") : "#{k}=\"#{v}\"" ]
+        [ argument, redacted ? redact("#{k}=#{escape_bash_string v.to_s}") : "#{k}=#{escape_bash_string v.to_s}" ]
       else
         [ argument, k ]
       end
@@ -25,5 +25,9 @@ module Mrsk::Utils
   # Copied from SSHKit::Backend::Abstract#redact to be available inside Commands classes
   def redact(arg) # Used in execute_command to hide redact() args a user passes in
     arg.to_s.extend(SSHKit::Redaction) # to_s due to our inability to extend Integer, etc
+  end
+
+  def escape_bash_string(string)
+    string.dump.gsub(/`/, '\\\\`')
   end
 end

--- a/lib/mrsk/utils.rb
+++ b/lib/mrsk/utils.rb
@@ -5,7 +5,7 @@ module Mrsk::Utils
   def argumentize(argument, attributes, redacted: false)
     Array(attributes).flat_map do |k, v|
       if v.present?
-        [ argument, redacted ? redact("#{k}=#{v}") : "#{k}=#{v}" ]
+        [ argument, redacted ? redact("#{k}=\"#{v}\"") : "#{k}=\"#{v}\"" ]
       else
         [ argument, k ]
       end

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -14,7 +14,7 @@ class CliAccessoryTest < CliTestCase
   end
 
   test "boot" do
-    assert_match "Running docker run --name app-mysql --detach --restart unless-stopped --log-opt max-size=10m --publish 3306:3306 -e [REDACTED] -e MYSQL_ROOT_HOST=% --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=app-mysql mysql:5.7 on 1.1.1.3", run_command("boot", "mysql")
+    assert_match "Running docker run --name app-mysql --detach --restart unless-stopped --log-opt max-size=10m --publish 3306:3306 -e [REDACTED] -e MYSQL_ROOT_HOST=\"%\" --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" mysql:5.7 on 1.1.1.3", run_command("boot", "mysql")
   end
 
   test "exec" do

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -49,11 +49,11 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
 
   test "run" do
     assert_equal \
-      "docker run --name app-mysql --detach --restart unless-stopped --log-opt max-size=10m --publish 3306:3306 -e MYSQL_ROOT_PASSWORD=secret123 -e MYSQL_ROOT_HOST=% --label service=app-mysql mysql:8.0",
+      "docker run --name app-mysql --detach --restart unless-stopped --log-opt max-size=10m --publish 3306:3306 -e MYSQL_ROOT_PASSWORD=\"secret123\" -e MYSQL_ROOT_HOST=\"%\" --label service=\"app-mysql\" mysql:8.0",
       @mysql.run.join(" ")
 
     assert_equal \
-      "docker run --name app-redis --detach --restart unless-stopped --log-opt max-size=10m --publish 6379:6379 -e SOMETHING=else --volume /var/lib/redis:/data --label service=app-redis --label cache=true redis:latest",
+      "docker run --name app-redis --detach --restart unless-stopped --log-opt max-size=10m --publish 6379:6379 -e SOMETHING=\"else\" --volume /var/lib/redis:/data --label service=\"app-redis\" --label cache=\"true\" redis:latest",
       @redis.run.join(" ")
   end
 
@@ -78,7 +78,7 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
 
   test "execute in new container" do
     assert_equal \
-      "docker run --rm -e MYSQL_ROOT_PASSWORD=secret123 -e MYSQL_ROOT_HOST=% mysql:8.0 mysql -u root",
+      "docker run --rm -e MYSQL_ROOT_PASSWORD=\"secret123\" -e MYSQL_ROOT_HOST=\"%\" mysql:8.0 mysql -u root",
       @mysql.execute_in_new_container("mysql", "-u", "root").join(" ")
   end
 
@@ -90,7 +90,7 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
 
   test "execute in new container over ssh" do
     @mysql.stub(:run_over_ssh, ->(cmd) { cmd.join(" ") }) do
-      assert_match %r|docker run -it --rm -e MYSQL_ROOT_PASSWORD=secret123 -e MYSQL_ROOT_HOST=% mysql:8.0 mysql -u root|,
+      assert_match %r|docker run -it --rm -e MYSQL_ROOT_PASSWORD=\"secret123\" -e MYSQL_ROOT_HOST=\"%\" mysql:8.0 mysql -u root|,
         @mysql.execute_in_new_container_over_ssh("mysql", "-u", "root")
     end
   end

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -14,7 +14,7 @@ class CommandsAppTest < ActiveSupport::TestCase
 
   test "run" do
     assert_equal \
-      "docker run --detach --restart unless-stopped --log-opt max-size=10m --name app-999 -e RAILS_MASTER_KEY=456 --label service=app --label role=web --label traefik.http.routers.app.rule='PathPrefix(`/`)' --label traefik.http.services.app.loadbalancer.healthcheck.path=/up --label traefik.http.services.app.loadbalancer.healthcheck.interval=1s --label traefik.http.middlewares.app.retry.attempts=3 --label traefik.http.middlewares.app.retry.initialinterval=500ms dhh/app:999",
+      "docker run --detach --restart unless-stopped --log-opt max-size=10m --name app-999 -e RAILS_MASTER_KEY=\"456\" --label service=\"app\" --label role=\"web\" --label traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\" --label traefik.http.services.app.loadbalancer.healthcheck.path=\"/up\" --label traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\" --label traefik.http.middlewares.app.retry.attempts=\"3\" --label traefik.http.middlewares.app.retry.initialinterval=\"500ms\" dhh/app:999",
       @app.run.join(" ")
   end
 
@@ -22,7 +22,7 @@ class CommandsAppTest < ActiveSupport::TestCase
     @config[:volumes] = ["/local/path:/container/path" ]
 
     assert_equal \
-      "docker run --detach --restart unless-stopped --log-opt max-size=10m --name app-999 -e RAILS_MASTER_KEY=456 --volume /local/path:/container/path --label service=app --label role=web --label traefik.http.routers.app.rule='PathPrefix(`/`)' --label traefik.http.services.app.loadbalancer.healthcheck.path=/up --label traefik.http.services.app.loadbalancer.healthcheck.interval=1s --label traefik.http.middlewares.app.retry.attempts=3 --label traefik.http.middlewares.app.retry.initialinterval=500ms dhh/app:999",
+      "docker run --detach --restart unless-stopped --log-opt max-size=10m --name app-999 -e RAILS_MASTER_KEY=\"456\" --volume /local/path:/container/path --label service=\"app\" --label role=\"web\" --label traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\" --label traefik.http.services.app.loadbalancer.healthcheck.path=\"/up\" --label traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\" --label traefik.http.middlewares.app.retry.attempts=\"3\" --label traefik.http.middlewares.app.retry.initialinterval=\"500ms\" dhh/app:999",
       @app.run.join(" ")
   end
 
@@ -30,7 +30,7 @@ class CommandsAppTest < ActiveSupport::TestCase
     @config[:healthcheck] = { "path" => "/healthz" }
 
     assert_equal \
-      "docker run --detach --restart unless-stopped --log-opt max-size=10m --name app-999 -e RAILS_MASTER_KEY=456 --label service=app --label role=web --label traefik.http.routers.app.rule='PathPrefix(`/`)' --label traefik.http.services.app.loadbalancer.healthcheck.path=/healthz --label traefik.http.services.app.loadbalancer.healthcheck.interval=1s --label traefik.http.middlewares.app.retry.attempts=3 --label traefik.http.middlewares.app.retry.initialinterval=500ms dhh/app:999",
+      "docker run --detach --restart unless-stopped --log-opt max-size=10m --name app-999 -e RAILS_MASTER_KEY=\"456\" --label service=\"app\" --label role=\"web\" --label traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\" --label traefik.http.services.app.loadbalancer.healthcheck.path=\"/healthz\" --label traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\" --label traefik.http.middlewares.app.retry.attempts=\"3\" --label traefik.http.middlewares.app.retry.initialinterval=\"500ms\" dhh/app:999",
       @app.run.join(" ")
   end
 
@@ -94,7 +94,7 @@ class CommandsAppTest < ActiveSupport::TestCase
 
   test "execute in new container" do
     assert_equal \
-      "docker run --rm -e RAILS_MASTER_KEY=456 dhh/app:999 bin/rails db:setup",
+      "docker run --rm -e RAILS_MASTER_KEY=\"456\" dhh/app:999 bin/rails db:setup",
       @app.execute_in_new_container("bin/rails", "db:setup").join(" ")
   end
 
@@ -106,7 +106,7 @@ class CommandsAppTest < ActiveSupport::TestCase
 
   test "execute in new container over ssh" do
     @app.stub(:run_over_ssh, ->(cmd, host:) { cmd.join(" ") }) do
-      assert_match %r|docker run -it --rm -e RAILS_MASTER_KEY=456 dhh/app:999 bin/rails c|,
+      assert_match %r|docker run -it --rm -e RAILS_MASTER_KEY=\"456\" dhh/app:999 bin/rails c|,
         @app.execute_in_new_container_over_ssh("bin/rails", "c", host: "app-1")
     end
   end

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -9,7 +9,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command
     assert_equal "multiarch", builder.name
     assert_equal \
-      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder mrsk-app-multiarch -t dhh/app:123 -t dhh/app:latest --label service=app .",
+      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder mrsk-app-multiarch -t dhh/app:123 -t dhh/app:latest --label service=\"app\" .",
       builder.push.join(" ")
   end
 
@@ -17,7 +17,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "multiarch" => false })
     assert_equal "native", builder.name
     assert_equal \
-      "docker build -t dhh/app:123 -t dhh/app:latest --label service=app . && docker push dhh/app:123",
+      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" . && docker push dhh/app:123",
       builder.push.join(" ")
   end
 
@@ -25,7 +25,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "local" => { }, "remote" => { } })
     assert_equal "multiarch/remote", builder.name
     assert_equal \
-      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder mrsk-app-multiarch-remote -t dhh/app:123 -t dhh/app:latest --label service=app .",
+      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder mrsk-app-multiarch-remote -t dhh/app:123 -t dhh/app:latest --label service=\"app\" .",
       builder.push.join(" ")
   end
 
@@ -33,42 +33,42 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "remote" => { "arch" => "amd64" } })
     assert_equal "native/remote", builder.name
     assert_equal \
-      "docker buildx build --push --platform linux/amd64 --builder mrsk-app-native-remote -t dhh/app:123 -t dhh/app:latest --label service=app .",
+      "docker buildx build --push --platform linux/amd64 --builder mrsk-app-native-remote -t dhh/app:123 -t dhh/app:latest --label service=\"app\" .",
       builder.push.join(" ")
   end
 
   test "build args" do
     builder = new_builder_command(builder: { "args" => { "a" => 1, "b" => 2 } })
     assert_equal \
-      "-t dhh/app:123 -t dhh/app:latest --label service=app --build-arg a=1 --build-arg b=2",
+      "-t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\"",
       builder.target.build_options.join(" ")
   end
 
   test "build secrets" do
     builder = new_builder_command(builder: { "secrets" => ["token_a", "token_b"] })
     assert_equal \
-      "-t dhh/app:123 -t dhh/app:latest --label service=app --secret id=token_a --secret id=token_b",
+      "-t dhh/app:123 -t dhh/app:latest --label service=\"app\" --secret id=\"token_a\" --secret id=\"token_b\"",
       builder.target.build_options.join(" ")
   end
 
   test "native push with build args" do
     builder = new_builder_command(builder: { "multiarch" => false, "args" => { "a" => 1, "b" => 2 } })
     assert_equal \
-      "docker build -t dhh/app:123 -t dhh/app:latest --label service=app --build-arg a=1 --build-arg b=2 . && docker push dhh/app:123",
+      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\" . && docker push dhh/app:123",
       builder.push.join(" ")
   end
 
   test "multiarch push with build args" do
     builder = new_builder_command(builder: { "args" => { "a" => 1, "b" => 2 } })
     assert_equal \
-      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder mrsk-app-multiarch -t dhh/app:123 -t dhh/app:latest --label service=app --build-arg a=1 --build-arg b=2 .",
+      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder mrsk-app-multiarch -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\" .",
       builder.push.join(" ")
   end
 
   test "native push with with build secrets" do
     builder = new_builder_command(builder: { "multiarch" => false, "secrets" => [ "a", "b" ] })
     assert_equal \
-      "docker build -t dhh/app:123 -t dhh/app:latest --label service=app --secret id=a --secret id=b . && docker push dhh/app:123",
+      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --secret id=\"a\" --secret id=\"b\" . && docker push dhh/app:123",
       builder.push.join(" ")
   end
 

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -72,20 +72,20 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
   end
 
   test "label args" do
-    assert_equal ["--label", "service=app-mysql"], @config.accessory(:mysql).label_args
-    assert_equal ["--label", "service=app-redis", "--label", "cache=true"], @config.accessory(:redis).label_args
+    assert_equal ["--label", "service=\"app-mysql\""], @config.accessory(:mysql).label_args
+    assert_equal ["--label", "service=\"app-redis\"", "--label", "cache=\"true\""], @config.accessory(:redis).label_args
   end
 
   test "env args with secret" do
     ENV["MYSQL_ROOT_PASSWORD"] = "secret123"
-    assert_equal ["-e", "MYSQL_ROOT_PASSWORD=secret123", "-e", "MYSQL_ROOT_HOST=%"], @config.accessory(:mysql).env_args
+    assert_equal ["-e", "MYSQL_ROOT_PASSWORD=\"secret123\"", "-e", "MYSQL_ROOT_HOST=\"%\""], @config.accessory(:mysql).env_args
     assert @config.accessory(:mysql).env_args[1].is_a?(SSHKit::Redaction)
   ensure
     ENV["MYSQL_ROOT_PASSWORD"] = nil
   end
 
   test "env args without secret" do
-    assert_equal ["-e", "SOMETHING=else"], @config.accessory(:redis).env_args
+    assert_equal ["-e", "SOMETHING=\"else\""], @config.accessory(:redis).env_args
   end
 
   test "volume args" do

--- a/test/configuration/role_test.rb
+++ b/test/configuration/role_test.rb
@@ -38,11 +38,11 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
   end
 
   test "label args" do
-    assert_equal [ "--label", "service=app", "--label", "role=workers" ], @config_with_roles.role(:workers).label_args
+    assert_equal [ "--label", "service=\"app\"", "--label", "role=\"workers\"" ], @config_with_roles.role(:workers).label_args
   end
 
   test "special label args for web" do
-    assert_equal [ "--label", "service=app", "--label", "role=web", "--label", "traefik.http.routers.app.rule='PathPrefix(`/`)'", "--label", "traefik.http.services.app.loadbalancer.healthcheck.path=/up", "--label", "traefik.http.services.app.loadbalancer.healthcheck.interval=1s", "--label", "traefik.http.middlewares.app.retry.attempts=3", "--label", "traefik.http.middlewares.app.retry.initialinterval=500ms"], @config.role(:web).label_args
+    assert_equal [ "--label", "service=\"app\"", "--label", "role=\"web\"", "--label", "traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\"", "--label", "traefik.http.services.app.loadbalancer.healthcheck.path=\"/up\"", "--label", "traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\"", "--label", "traefik.http.middlewares.app.retry.attempts=\"3\"", "--label", "traefik.http.middlewares.app.retry.initialinterval=\"500ms\""], @config.role(:web).label_args
   end
 
   test "custom labels" do
@@ -57,8 +57,8 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
   end
 
   test "overwriting default traefik label" do
-    @deploy[:labels] = { "traefik.http.routers.app.rule" => "'Host(`example.com`) || (Host(`example.org`) && Path(`/traefik`))'" }
-    assert_equal "'Host(`example.com`) || (Host(`example.org`) && Path(`/traefik`))'", @config.role(:web).labels["traefik.http.routers.app.rule"]
+    @deploy[:labels] = { "traefik.http.routers.app.rule" => "\"Host(\\`example.com\\`) || (Host(\\`example.org\\`) && Path(\\`/traefik\\`))\"" }
+    assert_equal "\"Host(\\`example.com\\`) || (Host(\\`example.org\\`) && Path(\\`/traefik\\`))\"", @config.role(:web).labels["traefik.http.routers.app.rule"]
   end
 
   test "default traefik label on non-web role" do
@@ -66,12 +66,12 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
       c[:servers]["beta"] = { "traefik" => "true", "hosts" => [ "1.1.1.5" ] }
     })
 
-    assert_equal [ "--label", "service=app", "--label", "role=beta", "--label", "traefik.http.routers.app.rule='PathPrefix(`/`)'", "--label", "traefik.http.services.app.loadbalancer.healthcheck.path=/up", "--label", "traefik.http.services.app.loadbalancer.healthcheck.interval=1s", "--label", "traefik.http.middlewares.app.retry.attempts=3", "--label", "traefik.http.middlewares.app.retry.initialinterval=500ms" ], config.role(:beta).label_args
+    assert_equal [ "--label", "service=\"app\"", "--label", "role=\"beta\"", "--label", "traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\"", "--label", "traefik.http.services.app.loadbalancer.healthcheck.path=\"/up\"", "--label", "traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\"", "--label", "traefik.http.middlewares.app.retry.attempts=\"3\"", "--label", "traefik.http.middlewares.app.retry.initialinterval=\"500ms\"" ], config.role(:beta).label_args
   end
 
   test "env overwritten by role" do
     assert_equal "redis://a/b", @config_with_roles.role(:workers).env["REDIS_URL"]
-    assert_equal ["-e", "REDIS_URL=redis://a/b", "-e", "WEB_CONCURRENCY=4"], @config_with_roles.role(:workers).env_args
+    assert_equal ["-e", "REDIS_URL=\"redis://a/b\"", "-e", "WEB_CONCURRENCY=\"4\""], @config_with_roles.role(:workers).env_args
   end
 
   test "env secret overwritten by role" do
@@ -97,7 +97,7 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
     ENV["REDIS_PASSWORD"] = "secret456"
     ENV["DB_PASSWORD"] = "secret123"
 
-    assert_equal ["-e", "REDIS_PASSWORD=secret456", "-e", "DB_PASSWORD=secret123", "-e", "REDIS_URL=redis://a/b", "-e", "WEB_CONCURRENCY=4"], @config_with_roles.role(:workers).env_args
+    assert_equal ["-e", "REDIS_PASSWORD=\"secret456\"", "-e", "DB_PASSWORD=\"secret123\"", "-e", "REDIS_URL=\"redis://a/b\"", "-e", "WEB_CONCURRENCY=\"4\""], @config_with_roles.role(:workers).env_args
   ensure
     ENV["REDIS_PASSWORD"] = nil
     ENV["DB_PASSWORD"] = nil
@@ -116,7 +116,7 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
 
     ENV["DB_PASSWORD"] = "secret123"
 
-    assert_equal ["-e", "DB_PASSWORD=secret123", "-e", "REDIS_URL=redis://a/b", "-e", "WEB_CONCURRENCY=4"], @config_with_roles.role(:workers).env_args
+    assert_equal ["-e", "DB_PASSWORD=\"secret123\"", "-e", "REDIS_URL=\"redis://a/b\"", "-e", "WEB_CONCURRENCY=\"4\""], @config_with_roles.role(:workers).env_args
   ensure
     ENV["DB_PASSWORD"] = nil
   end
@@ -133,7 +133,7 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
 
     ENV["REDIS_PASSWORD"] = "secret456"
 
-    assert_equal ["-e", "REDIS_PASSWORD=secret456", "-e", "REDIS_URL=redis://a/b", "-e", "WEB_CONCURRENCY=4"], @config_with_roles.role(:workers).env_args
+    assert_equal ["-e", "REDIS_PASSWORD=\"secret456\"", "-e", "REDIS_URL=\"redis://a/b\"", "-e", "WEB_CONCURRENCY=\"4\""], @config_with_roles.role(:workers).env_args
   ensure
     ENV["REDIS_PASSWORD"] = nil
   end

--- a/test/configuration/role_test.rb
+++ b/test/configuration/role_test.rb
@@ -95,9 +95,9 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
     }
 
     ENV["REDIS_PASSWORD"] = "secret456"
-    ENV["DB_PASSWORD"] = "secret123"
+    ENV["DB_PASSWORD"] = "secret&\"123"
 
-    assert_equal ["-e", "REDIS_PASSWORD=\"secret456\"", "-e", "DB_PASSWORD=\"secret123\"", "-e", "REDIS_URL=\"redis://a/b\"", "-e", "WEB_CONCURRENCY=\"4\""], @config_with_roles.role(:workers).env_args
+    assert_equal ["-e", "REDIS_PASSWORD=\"secret456\"", "-e", "DB_PASSWORD=\"secret&\\\"123\"", "-e", "REDIS_URL=\"redis://a/b\"", "-e", "WEB_CONCURRENCY=\"4\""], @config_with_roles.role(:workers).env_args
   ensure
     ENV["REDIS_PASSWORD"] = nil
     ENV["DB_PASSWORD"] = nil

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -89,7 +89,7 @@ class ConfigurationTest < ActiveSupport::TestCase
   end
 
   test "env args" do
-    assert_equal [ "-e", "REDIS_URL=redis://x/y" ], @config.env_args
+    assert_equal [ "-e", "REDIS_URL=\"redis://x/y\"" ], @config.env_args
   end
 
   test "env args with clear and secrets" do
@@ -98,7 +98,7 @@ class ConfigurationTest < ActiveSupport::TestCase
       env: { "clear" => { "PORT" => "3000" }, "secret" => [ "PASSWORD" ] }
     }) })
 
-    assert_equal [ "-e", "PASSWORD=secret123", "-e", "PORT=3000" ], config.env_args
+    assert_equal [ "-e", "PASSWORD=\"secret123\"", "-e", "PORT=\"3000\"" ], config.env_args
     assert config.env_args[1].is_a?(SSHKit::Redaction)
   ensure
     ENV["PASSWORD"] = nil
@@ -109,7 +109,7 @@ class ConfigurationTest < ActiveSupport::TestCase
       env: { "clear" => { "PORT" => "3000" } }
     }) })
 
-    assert_equal [ "-e", "PORT=3000" ], config.env_args
+    assert_equal [ "-e", "PORT=\"3000\"" ], config.env_args
   end
 
   test "env args with only secrets" do
@@ -118,7 +118,7 @@ class ConfigurationTest < ActiveSupport::TestCase
       env: { "secret" => [ "PASSWORD" ] }
     }) })
 
-    assert_equal [ "-e", "PASSWORD=secret123" ], config.env_args
+    assert_equal [ "-e", "PASSWORD=\"secret123\"" ], config.env_args
     assert config.env_args[1].is_a?(SSHKit::Redaction)
   ensure
     ENV["PASSWORD"] = nil
@@ -181,6 +181,6 @@ class ConfigurationTest < ActiveSupport::TestCase
   end
 
   test "to_h" do
-    assert_equal({ :roles=>["web"], :hosts=>["1.1.1.1", "1.1.1.2"], :primary_host=>"1.1.1.1", :version=>"missing", :repository=>"dhh/app", :absolute_image=>"dhh/app:missing", :service_with_version=>"app-missing", :env_args=>["-e", "REDIS_URL=redis://x/y"], :ssh_options=>{:user=>"root", :auth_methods=>["publickey"]}, :volume_args=>["--volume", "/local/path:/container/path"], :healthcheck=>{"path"=>"/up", "port"=>3000 }}, @config.to_h)
+    assert_equal({ :roles=>["web"], :hosts=>["1.1.1.1", "1.1.1.2"], :primary_host=>"1.1.1.1", :version=>"missing", :repository=>"dhh/app", :absolute_image=>"dhh/app:missing", :service_with_version=>"app-missing", :env_args=>["-e", "REDIS_URL=\"redis://x/y\""], :ssh_options=>{:user=>"root", :auth_methods=>["publickey"]}, :volume_args=>["--volume", "/local/path:/container/path"], :healthcheck=>{"path"=>"/up", "port"=>3000 }}, @config.to_h)
   end
 end


### PR DESCRIPTION
## What's the identified issue ?

Mrsk currently does not escape the command line arguments it concatenates for the docker commands.

This make mrsk very susceptible to unescaped characters errors, as the following example demonstrates with an environment string that contains the symbol `&` : 
```
env:
  clear:
    - THIS_WILL_FAIL=fdjksl&fejkl
```

Which subsequently creates this docker run issue : 
```
  INFO [a427b772] Running docker run -d --name healthcheck-hello-symfo -p 3999:80 --label service=healthcheck-hello-symfo THIS_WILL_FAIL=fdjksl&fejkl redacted:latest on redacted
  ERROR (SSHKit::Command::Failed): docker exit status: 127
docker stdout: Nothing written
docker stderr: bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
bash: line 1: -e: command not found
bash: line 1: fejkl: command not found
"docker run" requires at least 1 argument.
See 'docker run --help'.

Usage:  docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

Run a command in a new container
```

This is due to the `argumentize` function not escaping the characters.

## What fix does this PR introduce ?
This PR forces all `argumentized` CLI arguments to be escaped, thus making the produced commands safe to run.

## What's important to note
- Labels are argumentized the same way that environment variables are, which means I also had to change the way we use traefik labels that use backticks in the code. Result should be 1:1 with what existed before, but I also had to revamp most of the tests to account for this change. 
We might have wanted to make two different `argumentize` functions, but I don't love it because of code duplication and because I think it's always better to escape characters.

- In the future we might want to create a special case for integers, but iirc everything that bash passes is a string so I didn't do that here and noticed no behavior

Tests are passing and this has been tested on a mrsk deploy.
