### PR TITLE
Change default healthcheck port to 3000

### DIFF
--- a/lib/mrsk/commands/healthcheck.rb
+++ b/lib/mrsk/commands/healthcheck.rb
@@ -1,5 +1,5 @@
 class Mrsk::Commands::Healthcheck < Mrsk::Commands::Base
-  EXPOSED_PORT = 3999
+  EXPOSED_PORT = 3000
 
   def run
     web = config.role(:web)

--- a/test/commands/healthcheck_test.rb
+++ b/test/commands/healthcheck_test.rb
@@ -10,7 +10,7 @@ class CommandsHealthcheckTest < ActiveSupport::TestCase
 
   test "run" do
     assert_equal \
-      "docker run --detach --name healthcheck-app-123 --publish 3999:3000 --label service=healthcheck-app dhh/app:123",
+      "docker run --detach --name healthcheck-app-123 --publish 3000:3000 --label service=healthcheck-app dhh/app:123",
       new_command.run.join(" ")
   end
 
@@ -18,13 +18,13 @@ class CommandsHealthcheckTest < ActiveSupport::TestCase
     @config[:healthcheck] = { "port" => 3001 }
 
     assert_equal \
-      "docker run --detach --name healthcheck-app-123 --publish 3999:3001 --label service=healthcheck-app dhh/app:123",
+      "docker run --detach --name healthcheck-app-123 --publish 3000:3001 --label service=healthcheck-app dhh/app:123",
       new_command.run.join(" ")
   end
 
   test "curl" do
     assert_equal \
-      "curl --silent --output /dev/null --write-out '%{http_code}' --max-time 2 http://localhost:3999/up",
+      "curl --silent --output /dev/null --write-out '%{http_code}' --max-time 2 http://localhost:3000/up",
       new_command.curl.join(" ")
   end
 
@@ -32,7 +32,7 @@ class CommandsHealthcheckTest < ActiveSupport::TestCase
     @config[:healthcheck] = { "path" => "/healthz" }
 
     assert_equal \
-      "curl --silent --output /dev/null --write-out '%{http_code}' --max-time 2 http://localhost:3999/healthz",
+      "curl --silent --output /dev/null --write-out '%{http_code}' --max-time 2 http://localhost:3000/healthz",
       new_command.curl.join(" ")
   end
 


### PR DESCRIPTION
The documentation states that the default healthcheck port is 3000, but mrsk seems to be hitting 3999. This PR changes mrsk's default to match the documentation again!

~~Noticed the healthcheck tests are failing and I'm looking into it now :(~~ Fixed.

In retrospect I probably should have created an issue first and worked off that. If you'd prefer that just let me know! I'm actively using mrsk on soon-to-be production environments, so I'm very motivated to help out where I can!