### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ruby
+{
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers/features/ruby:1": {}
+  }
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "ruby --version",
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}


### PR DESCRIPTION
This PR adds a configuration for a [devcontainer](https://containers.dev). I added [Ubuntu](https://github.com/devcontainers/images/tree/main/src/base-ubuntu) as the base image and included the [Ruby](https://github.com/devcontainers/features/tree/main/src/ruby) feature set. 

Other base images—such as Debian or Alpine—could work as well, but Ubuntu seemed like a good one to start with.

--- 


For background, a devcontainer configuration helps create a container-based development environment that includes all the tools needed to work in a given repository, without the need to modify a user's regular computing environment.