### PR TITLE
Destination aware container names

### DIFF
--- a/lib/mrsk/commands/app.rb
+++ b/lib/mrsk/commands/app.rb
@@ -6,7 +6,7 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
       "--detach",
       "--restart unless-stopped",
       "--log-opt", "max-size=#{MAX_LOG_SIZE}",
-      "--name", service_with_version,
+      "--name", service_with_version_and_destination,
       *role.env_args,
       *config.volume_args,
       *role.label_args,
@@ -15,7 +15,7 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
   end
 
   def start
-    docker :start, service_with_version
+    docker :start, service_with_version_and_destination
   end
 
   def stop(version: nil)
@@ -25,7 +25,7 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
   end
 
   def info
-    docker :ps, *service_filter
+    docker :ps, *service_filter_with_destination
   end
 
 
@@ -50,7 +50,7 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
   def execute_in_existing_container(*command, interactive: false)
     docker :exec,
       ("-it" if interactive),
-      config.service_with_version,
+      service_with_version_and_destination,
       *command
   end
 
@@ -74,13 +74,13 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
 
 
   def current_container_id
-    docker :ps, "--quiet", *service_filter
+    docker :ps, "--quiet", *service_filter_with_destination
   end
 
   def current_running_version
     # FIXME: Find more graceful way to extract the version from "app-version" than using sed and tail!
     pipe \
-      docker(:ps, "--filter", "label=service=#{config.service}", "--format", '"{{.Names}}"'),
+      docker(:ps, *service_filter_with_destination, "--format", '"{{.Names}}"'),
       %(sed 's/-/\\n/g'),
       "tail -n 1"
   end
@@ -99,7 +99,7 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
 
 
   def list_containers
-    docker :container, :ls, "--all", *service_filter
+    docker :container, :ls, "--all", *service_filter_with_destination
   end
 
   def list_container_names
@@ -108,12 +108,12 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
 
   def remove_container(version:)
     pipe \
-      container_id_for(container_name: service_with_version(version)),
+      container_id_for(container_name: service_with_version_and_destination(version)),
       xargs(docker(:container, :rm))
   end
 
   def remove_containers
-    docker :container, :prune, "--force", *service_filter
+    docker :container, :prune, "--force", *service_filter_with_destination
   end
 
   def list_images
@@ -126,19 +126,23 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
 
 
   private
-    def service_with_version(version = nil)
-      if version
-        "#{config.service}-#{version}"
-      else
-        config.service_with_version
-      end
+    def service_with_version_and_destination(version = nil)
+      [ config.service, config.destination, version || config.version ].compact.join("-")
     end
 
     def container_id_for_version(version)
-      container_id_for(container_name: service_with_version(version))    
+      container_id_for(container_name: service_with_version_and_destination(version))
     end
 
     def service_filter
       [ "--filter", "label=service=#{config.service}" ]
+    end
+
+    def service_filter_with_destination
+      if config.destination
+        service_filter << "label=destination=#{config.destination}"
+      else
+        service_filter
+      end
     end
 end

--- a/lib/mrsk/commands/auditor.rb
+++ b/lib/mrsk/commands/auditor.rb
@@ -21,7 +21,11 @@ class Mrsk::Commands::Auditor < Mrsk::Commands::Base
 
   private
     def audit_log_file
-      "mrsk-#{config.service}-audit.log"
+      if config.destination
+        "mrsk-#{config.service}-#{config.destination}-audit.log"
+      else
+        "mrsk-#{config.service}-audit.log"
+      end
     end
 
     def tagged_record_line(line)

--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -10,6 +10,7 @@ class Mrsk::Configuration
   delegate :argumentize, :argumentize_env_with_secrets, to: Mrsk::Utils
 
   attr_accessor :version
+  attr_accessor :destination
   attr_accessor :raw_config
 
   class << self
@@ -19,7 +20,7 @@ class Mrsk::Configuration
           config.deep_merge! \
             load_config_file destination_config_file(base_config_file, destination)
         end
-      end, version: version)
+      end, destination: destination, version: version)
     end
 
     private
@@ -37,8 +38,9 @@ class Mrsk::Configuration
       end
   end
 
-  def initialize(raw_config, version: "missing", validate: true)
+  def initialize(raw_config, destination: nil, version: "missing", validate: true)
     @raw_config = ActiveSupport::InheritableOptions.new(raw_config)
+    @destination = destination
     @version = version
     valid? if validate
   end

--- a/lib/mrsk/configuration/role.rb
+++ b/lib/mrsk/configuration/role.rb
@@ -52,7 +52,11 @@ class Mrsk::Configuration::Role
     end
 
     def default_labels
-      { "service" => config.service, "role" => name }
+      if config.destination
+        { "service" => config.service, "role" => name, "destination" => config.destination }
+      else
+        { "service" => config.service, "role" => name }
+      end
     end
 
     def traefik_labels

--- a/test/commands/auditor_test.rb
+++ b/test/commands/auditor_test.rb
@@ -14,6 +14,14 @@ class CommandsAuditorTest < ActiveSupport::TestCase
       new_command.record("app removed container").join(" ")
   end
 
+  test "record with destination" do
+    @destination = "staging"
+
+    assert_match \
+      /echo '.* app removed container' >> mrsk-app-staging-audit.log/,
+      new_command.record("app removed container").join(" ")
+  end
+
   test "broadcast" do
     assert_match \
       /bin\/audit_broadcast '\[.*\] app removed container'/,
@@ -22,6 +30,6 @@ class CommandsAuditorTest < ActiveSupport::TestCase
 
   private
     def new_command
-      Mrsk::Commands::Auditor.new(Mrsk::Configuration.new(@config, version: "123"))
+      Mrsk::Commands::Auditor.new(Mrsk::Configuration.new(@config, destination: @destination, version: "123"))
     end
 end


### PR DESCRIPTION
I started looking into having role aware container names but that turned out to be quite a big undertaking. So I started with destinations instead to see where it could head.

This PR is a start to have destination aware container names so **different destinations** of the **same service** can run on the **same server**.

This doesn't work right now:

```yml
# config/deploy.yml
service: app

# config/deploy.staging.yml
web:
  - 1.1.1.1

# config/deploy.demo.yml
web:
  - 1.1.1.1
```

… as both docker containers would have the same name `app-<version>` on 1.1.1.1. The PR adds - if present - the destination as part of the container name, ending up as `app-staging-<version>` and `app-demo-<version>`.

I started with `Mrsk::Commands::App` and before changing all of the other commands: Is this the way we want it to be? It'll include some if conditions on whether or not `MRSK.destination` (or `config.destination`) is truthy or not.

Another approach could be to default the destination to `"production"` if it's missing. This would probably be simpler but is more chatty in regards to the container names (if no destination is used it would be `app-production-<versions>` instead of `app-<version>`).
