### PR TITLE
Allow setting the Dockerfile and the Docker build context when building

### DIFF
--- a/lib/mrsk/commands/builder/base.rb
+++ b/lib/mrsk/commands/builder/base.rb
@@ -10,7 +10,8 @@ class Mrsk::Commands::Builder::Base < Mrsk::Commands::Base
   end
 
   def build_options
-    [ *build_tags, *build_labels, *build_args, *build_secrets ]
+    [ *build_tags, *build_labels, *build_args, *build_secrets, *build_dockerfile ]
+  end
   end
 
   private
@@ -30,11 +31,19 @@ class Mrsk::Commands::Builder::Base < Mrsk::Commands::Base
       argumentize "--secret", secrets.collect { |secret| [ "id", secret ] }
     end
 
+    def build_dockerfile
+      argumentize "--file", dockerfile
+    end
+
     def args
       (config.builder && config.builder["args"]) || {}
     end
 
     def secrets
       (config.builder && config.builder["secrets"]) || []
+    end
+
+    def dockerfile
+      (config.builder && config.builder["dockerfile"]) || "Dockerfile"
     end
 end

--- a/lib/mrsk/commands/builder/base.rb
+++ b/lib/mrsk/commands/builder/base.rb
@@ -12,6 +12,9 @@ class Mrsk::Commands::Builder::Base < Mrsk::Commands::Base
   def build_options
     [ *build_tags, *build_labels, *build_args, *build_secrets, *build_dockerfile ]
   end
+
+  def build_context
+    context
   end
 
   private
@@ -45,5 +48,9 @@ class Mrsk::Commands::Builder::Base < Mrsk::Commands::Base
 
     def dockerfile
       (config.builder && config.builder["dockerfile"]) || "Dockerfile"
+    end
+
+    def context
+      (config.builder && config.builder["context"]) || "."
     end
 end

--- a/lib/mrsk/commands/builder/multiarch.rb
+++ b/lib/mrsk/commands/builder/multiarch.rb
@@ -13,7 +13,7 @@ class Mrsk::Commands::Builder::Multiarch < Mrsk::Commands::Builder::Base
       "--platform", "linux/amd64,linux/arm64",
       "--builder", builder_name,
       *build_options,
-      "."
+      build_context
   end
 
   def info

--- a/lib/mrsk/commands/builder/native.rb
+++ b/lib/mrsk/commands/builder/native.rb
@@ -9,7 +9,7 @@ class Mrsk::Commands::Builder::Native < Mrsk::Commands::Builder::Base
 
   def push
     combine \
-      docker(:build, *build_options, "."),
+      docker(:build, *build_options, build_context),
       docker(:push, config.absolute_image)
   end
 

--- a/lib/mrsk/commands/builder/native/remote.rb
+++ b/lib/mrsk/commands/builder/native/remote.rb
@@ -17,7 +17,7 @@ class Mrsk::Commands::Builder::Native::Remote < Mrsk::Commands::Builder::Native
       "--platform", platform,
       "--builder", builder_name,
       *build_options,
-      "."
+      build_context
   end
 
   def info

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -9,7 +9,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command
     assert_equal "multiarch", builder.name
     assert_equal \
-      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder mrsk-app-multiarch -t dhh/app:123 -t dhh/app:latest --label service=\"app\" .",
+      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder mrsk-app-multiarch -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile .",
       builder.push.join(" ")
   end
 
@@ -17,7 +17,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "multiarch" => false })
     assert_equal "native", builder.name
     assert_equal \
-      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" . && docker push dhh/app:123",
+      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . && docker push dhh/app:123",
       builder.push.join(" ")
   end
 
@@ -25,7 +25,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "local" => { }, "remote" => { } })
     assert_equal "multiarch/remote", builder.name
     assert_equal \
-      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder mrsk-app-multiarch-remote -t dhh/app:123 -t dhh/app:latest --label service=\"app\" .",
+      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder mrsk-app-multiarch-remote -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile .",
       builder.push.join(" ")
   end
 
@@ -33,42 +33,49 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "remote" => { "arch" => "amd64" } })
     assert_equal "native/remote", builder.name
     assert_equal \
-      "docker buildx build --push --platform linux/amd64 --builder mrsk-app-native-remote -t dhh/app:123 -t dhh/app:latest --label service=\"app\" .",
+      "docker buildx build --push --platform linux/amd64 --builder mrsk-app-native-remote -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile .",
       builder.push.join(" ")
   end
 
   test "build args" do
     builder = new_builder_command(builder: { "args" => { "a" => 1, "b" => 2 } })
     assert_equal \
-      "-t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\"",
+      "-t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\" --file Dockerfile",
       builder.target.build_options.join(" ")
   end
 
   test "build secrets" do
     builder = new_builder_command(builder: { "secrets" => ["token_a", "token_b"] })
     assert_equal \
-      "-t dhh/app:123 -t dhh/app:latest --label service=\"app\" --secret id=\"token_a\" --secret id=\"token_b\"",
+      "-t dhh/app:123 -t dhh/app:latest --label service=\"app\" --secret id=\"token_a\" --secret id=\"token_b\" --file Dockerfile",
+      builder.target.build_options.join(" ")
+  end
+
+  test "build dockerfile" do
+    builder = new_builder_command(builder: { "dockerfile" => "Dockerfile.xyz" })
+    assert_equal \
+      "-t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile.xyz",
       builder.target.build_options.join(" ")
   end
 
   test "native push with build args" do
     builder = new_builder_command(builder: { "multiarch" => false, "args" => { "a" => 1, "b" => 2 } })
     assert_equal \
-      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\" . && docker push dhh/app:123",
+      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\" --file Dockerfile . && docker push dhh/app:123",
       builder.push.join(" ")
   end
 
   test "multiarch push with build args" do
     builder = new_builder_command(builder: { "args" => { "a" => 1, "b" => 2 } })
     assert_equal \
-      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder mrsk-app-multiarch -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\" .",
+      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder mrsk-app-multiarch -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\" --file Dockerfile .",
       builder.push.join(" ")
   end
 
   test "native push with with build secrets" do
     builder = new_builder_command(builder: { "multiarch" => false, "secrets" => [ "a", "b" ] })
     assert_equal \
-      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --secret id=\"a\" --secret id=\"b\" . && docker push dhh/app:123",
+      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --secret id=\"a\" --secret id=\"b\" --file Dockerfile . && docker push dhh/app:123",
       builder.push.join(" ")
   end
 

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -58,6 +58,13 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       builder.target.build_options.join(" ")
   end
 
+  test "build context" do
+    builder = new_builder_command(builder: { "context" => ".." })
+    assert_equal \
+      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder mrsk-app-multiarch -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile ..",
+      builder.push.join(" ")
+  end
+
   test "native push with build args" do
     builder = new_builder_command(builder: { "multiarch" => false, "args" => { "a" => 1, "b" => 2 } })
     assert_equal \


### PR DESCRIPTION
Hey there 👋 

We're using a monorepo and gems get included in the apps via path (e.g. `gem 'mygem', path: '../mygem'`). As Docker limits everything to the context (default `.`), including gems outside of the context does not work. I'm no Docker expert, but setting the context to `..` and specifying the Dockerfile with `--file Dockerfile` seems to do the trick. 

This PR:
- adds a `context` option to the builder config
- adds a `dockerfile` option to the builder config
  The default value for this is `Dockerfile` and it will always be appended to the build command. This is helpful if someone wants to use different Dockerfiles (e.g. `Dockerfile.development`). I'm not sure if this is feasible as a config option at all, but to support passing the context, the `--file` argument seems to be needed in the build command (and it mayber is a little more explicit). Otherwise, Docker would look for the Dockerfile in the root of the context.


 The build configuration would look as follows:
 
```yaml
# Set context
builder:
  context: ".."

# Use different Dockerfile
builder:
  dockerfile: Dockerfile.xyz

# Set context and Dockerfile
builder:
  context: ".."
  dockerfile: "../Dockerfile.xyz" # Dockerfile is in the parent directory
```

It would also be possible to just allow configuring the `context` and making sure the `--file Dockerfile` argument always gets passed to the build command (without it being a configuration option).