### PR TITLE
Publish Docker image for each release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,10 @@
 name: Docker
 
 on:
-  push:
-    branches: main
+  release:
+    types: [created]
+    tags:
+      - 'v*'
 
 jobs:
   build-and-push-image:
@@ -14,6 +16,10 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+      -
+        name: Extract Version Number
+        id: extract_version
+        run: echo "::set-output name=version::${{ github.ref | replace('refs/tags/v', '') }}"
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -34,4 +40,6 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/mrsked/mrsk:latest
+          tags: |
+            ghcr.io/mrsked/mrsk:latest
+            ghcr.io/mrsked/mrsk:${{ steps.extract_version.outputs.version }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,7 +19,7 @@ jobs:
       -
         name: Extract Version Number
         id: extract_version
-        run: echo "::set-output name=version::${{ github.ref | replace('refs/tags/v', '') }}"
+        run: echo "::set-output name=version::${{ github.ref | replace('refs/tags/', '') }}"
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
The purpose if this change is to publish a Docker image for each release, tagged with the version number.

For example, next patch should build, tag and publish image: `ghcr.io/mrsked/mrsk:v0.9.0`

https://github.com/mrsked/mrsk/issues/62#issuecomment-1454768378

I don't know how to test it though, so I'm not 100% sure that it works. Please advice :)