### PR TITLE
Add ed25519 and bcrypt_pbkdf to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,3 @@ gemspec
 gem "debug"
 gem "mocha"
 gem "railties"
-gem "ed25519"
-gem "bcrypt_pbkdf"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,9 @@ PATH
   specs:
     mrsk (0.8.4)
       activesupport (>= 7.0)
+      bcrypt_pbkdf (~> 1.0)
       dotenv (~> 2.8)
+      ed25519 (~> 1.2)
       sshkit (~> 1.21)
       thor (~> 1.2)
       zeitwerk (~> 2.5)
@@ -98,9 +100,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  bcrypt_pbkdf
   debug
-  ed25519
   mocha
   mrsk!
   railties

--- a/mrsk.gemspec
+++ b/mrsk.gemspec
@@ -17,4 +17,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thor", "~> 1.2"
   spec.add_dependency "dotenv", "~> 2.8"
   spec.add_dependency "zeitwerk", "~> 2.5"
+  spec.add_dependency "ed25519", "~> 1.2"
+  spec.add_dependency "bcrypt_pbkdf", "~> 1.0"
 end


### PR DESCRIPTION
I can see both gems have been added to the `Gemfile` in https://github.com/mrsked/mrsk/commit/21c6a1f1ba8592f47621641781adfd3d4e4dedcd but I am still getting the error

```
$ mrsk deploy
Ensure Docker is installed...
  INFO [b09005e2] Running which docker || (apt-get update -y && apt-get install docker.io -y) on 5.161.132.150
  INFO [659aca77] Running which docker || (apt-get update -y && apt-get install docker.io -y) on 192.168.0.2
  Finished all in 0.4 seconds
/Users/axel/.rvm/gems/ruby-3.2.0/gems/net-ssh-7.0.1/lib/net/ssh/authentication/ed25519_loader.rb:19:in `raiseUnlessLoaded': unsupported key type `ssh-ed25519' (NotImplementedError)
net-ssh requires the following gems for ed25519 support:
 * ed25519 (>= 1.2, < 2.0)
 * bcrypt_pbkdf (>= 1.0, < 2.0)
See https://github.com/net-ssh/net-ssh/issues/565 for more information
Gem::MissingSpecError : "Could not find 'ed25519' (~> 1.2) among 312 total gem(s)
```
with my locally installed `mrsk` gem

```
$ mrsk version
0.8.4
```

I added them to the `mrsk.gemspec` and in my project installed the gem as dev dependency directly from my Github branch which solved the SSH connection error.

Hope this helps!