### PR TITLE
Customizable Traefik host port

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,15 @@ traefik:
 
 This will start the traefik container with `--accesslog=true accesslog.format=json`.
 
+### Traefik's host port binding
+
+By default Traefik binds to port 80 of the host machine, it can be configured to use an alternative port:
+
+```yaml
+traefik:
+  host_port: 8080
+```
+
 ### Configuring build args for new images
 
 Build arguments that aren't secret can also be configured:

--- a/lib/mrsk/commands/traefik.rb
+++ b/lib/mrsk/commands/traefik.rb
@@ -4,7 +4,7 @@ class Mrsk::Commands::Traefik < Mrsk::Commands::Base
       "--detach",
       "--restart", "unless-stopped",
       "--log-opt", "max-size=#{MAX_LOG_SIZE}",
-      "--publish", "80:80",
+      "--publish", port,
       "--volume", "/var/run/docker.sock:/var/run/docker.sock",
       "traefik",
       "--providers.docker",
@@ -43,6 +43,10 @@ class Mrsk::Commands::Traefik < Mrsk::Commands::Base
 
   def remove_image
     docker :image, :prune, "--all", "--force", "--filter", "label=org.opencontainers.image.title=Traefik"
+  end
+
+  def port
+    "#{config.raw_config.traefik.fetch("host_port", "80")}:80"
   end
 
   private

--- a/test/commands/traefik_test.rb
+++ b/test/commands/traefik_test.rb
@@ -12,6 +12,11 @@ class CommandsTraefikTest < ActiveSupport::TestCase
     assert_equal \
       "docker run --name traefik --detach --restart unless-stopped --log-opt max-size=10m --publish 80:80 --volume /var/run/docker.sock:/var/run/docker.sock traefik --providers.docker --log.level=DEBUG --accesslog.format json --metrics.prometheus.buckets 0.1,0.3,1.2,5.0",
       new_command.run.join(" ")
+
+    @config[:traefik]["host_port"] = "8080"
+    assert_equal \
+      "docker run --name traefik --detach --restart unless-stopped --log-opt max-size=10m --publish 8080:80 --volume /var/run/docker.sock:/var/run/docker.sock traefik --providers.docker --log.level=DEBUG --accesslog.format json --metrics.prometheus.buckets 0.1,0.3,1.2,5.0",
+      new_command.run.join(" ")
   end
 
   test "traefik start" do


### PR DESCRIPTION
Allow users to free up port 80 on the host machine, without losing Traefik's Docker routing super-powers. 

My usecase is using MRSK to deploy a Rails app to a server already running Caddy on port 80.