### PR TITLE
Ensure curl is installed on hosts during bootstrapping

### DIFF
--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -11,7 +11,7 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
   desc "deploy", "Deploy app to servers"
   def deploy
     runtime = print_runtime do
-      say "Ensure Docker is installed...", :magenta
+      say "Ensure curl and Docker are installed...", :magenta
       invoke "mrsk:cli:server:bootstrap"
 
       say "Log into image registry...", :magenta
@@ -173,7 +173,7 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
   desc "registry", "Login and -out of the image registry"
   subcommand "registry", Mrsk::Cli::Registry
 
-  desc "server", "Bootstrap servers with Docker"
+  desc "server", "Bootstrap servers with curl and Docker"
   subcommand "server", Mrsk::Cli::Server
 
   desc "traefik", "Manage Traefik load balancer"

--- a/lib/mrsk/cli/server.rb
+++ b/lib/mrsk/cli/server.rb
@@ -1,6 +1,15 @@
 class Mrsk::Cli::Server < Mrsk::Cli::Base
-  desc "bootstrap", "Ensure Docker is installed on servers"
+  desc "bootstrap", "Ensure curl and Docker are installed on servers"
   def bootstrap
-    on(MRSK.hosts + MRSK.accessory_hosts) { execute "which docker || (apt-get update -y && apt-get install docker.io -y)" }
+    on(MRSK.hosts + MRSK.accessory_hosts) do
+      dependencies_to_install = [].tap do |dependencies|
+        dependencies << "curl" unless execute "which curl", raise_on_non_zero_exit: false
+        dependencies << "docker.io" unless execute "which docker", raise_on_non_zero_exit: false
+      end
+
+      if dependencies_to_install.any?
+        execute "apt-get update -y && apt-get install #{dependencies_to_install.join(' ')} -y)"
+      end
+    end
   end
 end

--- a/lib/mrsk/cli/server.rb
+++ b/lib/mrsk/cli/server.rb
@@ -2,13 +2,13 @@ class Mrsk::Cli::Server < Mrsk::Cli::Base
   desc "bootstrap", "Ensure curl and Docker are installed on servers"
   def bootstrap
     on(MRSK.hosts + MRSK.accessory_hosts) do
-      dependencies_to_install = [].tap do |dependencies|
+      dependencies_to_install = Array.new.tap do |dependencies|
         dependencies << "curl" unless execute "which curl", raise_on_non_zero_exit: false
         dependencies << "docker.io" unless execute "which docker", raise_on_non_zero_exit: false
       end
 
       if dependencies_to_install.any?
-        execute "apt-get update -y && apt-get install #{dependencies_to_install.join(' ')} -y)"
+        execute "apt-get update -y && apt-get install #{dependencies_to_install.join(" ")} -y)"
       end
     end
   end

--- a/test/cli/server_test.rb
+++ b/test/cli/server_test.rb
@@ -1,0 +1,16 @@
+require_relative "cli_test_case"
+
+class CliServerTest < CliTestCase
+  test "bootstrap" do
+    run_command("bootstrap").tap do |output|
+      assert_match /which curl/, output
+      assert_match /which docker/, output
+      assert_match /apt-get update -y && apt-get install curl docker.io -y/, output
+    end
+  end
+
+  private
+    def run_command(*command)
+      stdouted { Mrsk::Cli::Server.start([*command, "-c", "test/fixtures/deploy_with_accessories.yml"]) }
+    end
+end


### PR DESCRIPTION
Debian minimal (and others) doesn't come with `curl` installed out of the box, MRSK should check and resolve this during bootstrapping.

This is the root cause of the issue - but possibly worth opening an issue for the lack of information provided during failing healthchecks due to things like curl missing – i.e. no obvious error is raised beyond `INFO Health check against /up failed to respond, retrying in Ns...` – happy to open an issue for this if people would like.