### PR TITLE
Allow registry username to reference a secret 

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,13 @@ The default registry is Docker Hub, but you can change it using `registry/server
 ```yaml
 registry:
   server: registry.digitalocean.com
-  username: registry-user-name
-  password: <%= ENV.fetch("MRSK_REGISTRY_PASSWORD") %>
+  username:  
+    - DOCKER_REGISTRY_TOKEN
+  password: 
+    - DOCKER_REGISTRY_TOKEN
 ```
+
+A reference to secret `DOCKER_REGISTRY_TOKEN` will look for `ENV["DOCKER_REGISTRY_TOKEN"]` on the machine running MRSK.
 
 ### Using a different SSH user than root
 

--- a/lib/mrsk/commands/registry.rb
+++ b/lib/mrsk/commands/registry.rb
@@ -2,7 +2,7 @@ class Mrsk::Commands::Registry < Mrsk::Commands::Base
   delegate :registry, to: :config
 
   def login
-    docker :login, registry["server"], "-u", redact(registry["username"]), "-p", redact(lookup_password)
+    docker :login, registry["server"], "-u", redact_credentials("username"), "-p", redact_credentials("password")
   end
 
   def logout
@@ -10,11 +10,13 @@ class Mrsk::Commands::Registry < Mrsk::Commands::Base
   end
 
   private
-    def lookup_password
-      if registry["password"].is_a?(Array)
-        ENV.fetch(registry["password"].first).dup
-      else
-        registry["password"]
-      end
+    def redact_credentials(key)
+      value = if registry[key].is_a?(Array)
+          ENV.fetch(registry[key].first).dup
+        else
+          registry[key]
+        end
+
+      redact(value)
     end
 end

--- a/lib/mrsk/commands/registry.rb
+++ b/lib/mrsk/commands/registry.rb
@@ -2,7 +2,7 @@ class Mrsk::Commands::Registry < Mrsk::Commands::Base
   delegate :registry, to: :config
 
   def login
-    docker :login, registry["server"], "-u", redact_credentials("username"), "-p", redact_credentials("password")
+    docker :login, registry["server"], "-u", redact(lookup("username")), "-p", redact(lookup("password"))
   end
 
   def logout
@@ -10,13 +10,11 @@ class Mrsk::Commands::Registry < Mrsk::Commands::Base
   end
 
   private
-    def redact_credentials(key)
-      value = if registry[key].is_a?(Array)
-          ENV.fetch(registry[key].first).dup
-        else
-          registry[key]
-        end
-
-      redact(value)
+    def lookup(key)
+      if registry[key].is_a?(Array)
+        ENV.fetch(registry[key].first).dup
+      else
+        registry[key]
+      end
     end
 end

--- a/test/commands/registry_test.rb
+++ b/test/commands/registry_test.rb
@@ -30,6 +30,17 @@ class CommandsRegistryTest < ActiveSupport::TestCase
     ENV.delete("MRSK_REGISTRY_PASSWORD")
   end
 
+  test "registry login with ENV username" do
+    ENV["MRSK_REGISTRY_USERNAME"] = "also-secret"
+    @config[:registry]["username"] = [ "MRSK_REGISTRY_USERNAME" ]
+
+    assert_equal \
+      "docker login hub.docker.com -u also-secret -p secret",
+      @registry.login.join(" ")
+  ensure
+    ENV.delete("MRSK_REGISTRY_USERNAME")
+  end
+
   test "registry logout" do
     assert_equal \
       "docker logout hub.docker.com",


### PR DESCRIPTION
From DigitalOcean docs:

> For CI systems that support configuring registry authentication via username and password, use a DigitalOcean API **token** as **both the username and the password**. The API token must have read/write privileges to push to your registry.

This PR enables users to configure their registry details with a secret for username, like this:

```yaml
registry:
  server: registry.digitalocean.com
  username:  
    - SECRET_REGISTRY_TOKEN
  password: 
    - SECRET_REGISTRY_TOKEN
```

solves #89