### PR TITLE
fix: mrsk run command fails when traefik config is empty

### DIFF
--- a/lib/mrsk/commands/traefik.rb
+++ b/lib/mrsk/commands/traefik.rb
@@ -1,4 +1,6 @@
 class Mrsk::Commands::Traefik < Mrsk::Commands::Base
+  CONTAINER_PORT = 80
+
   def run
     docker :run, "--name traefik",
       "--detach",
@@ -46,12 +48,15 @@ class Mrsk::Commands::Traefik < Mrsk::Commands::Base
   end
 
   def port    
-    traefik_port = config.raw_config.dig(:traefik, "host_port") || 80
-    "#{traefik_port}:80"
+    "#{host_port}:#{CONTAINER_PORT}"
   end
 
   private
     def cmd_args
       (config.raw_config.dig(:traefik, "args") || { }).collect { |(key, value)| [ "--#{key}", value ] }.flatten
+    end
+
+    def host_port
+      config.raw_config.dig(:traefik, "host_port") || CONTAINER_PORT
     end
 end

--- a/lib/mrsk/commands/traefik.rb
+++ b/lib/mrsk/commands/traefik.rb
@@ -45,8 +45,9 @@ class Mrsk::Commands::Traefik < Mrsk::Commands::Base
     docker :image, :prune, "--all", "--force", "--filter", "label=org.opencontainers.image.title=Traefik"
   end
 
-  def port
-    "#{config.raw_config.traefik.fetch("host_port", "80")}:80"
+  def port    
+    traefik_port = config.raw_config.dig(:traefik, "host_port") || 80
+    "#{traefik_port}:80"
   end
 
   private

--- a/test/commands/traefik_test.rb
+++ b/test/commands/traefik_test.rb
@@ -19,6 +19,14 @@ class CommandsTraefikTest < ActiveSupport::TestCase
       new_command.run.join(" ")
   end
 
+  test "run without configuration" do
+    @config.delete(:traefik)
+
+    assert_equal \
+      "docker run --name traefik --detach --restart unless-stopped --log-opt max-size=10m --publish 80:80 --volume /var/run/docker.sock:/var/run/docker.sock traefik --providers.docker --log.level=DEBUG",
+      new_command.run.join(" ")
+  end
+
   test "traefik start" do
     assert_equal \
       "docker container start traefik",


### PR DESCRIPTION
A small fix for https://github.com/mrsked/mrsk/pull/85. 

```console
$ mrsk deploy
....
Ensure Traefik is running...
  Finished all in 80.9 seconds
  ERROR (NoMethodError): undefined method `fetch' for nil:NilClass
```