### PR TITLE
Custom options per role

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,27 @@ servers:
       my-label: "50"
 ```
 
+### Using container options
+
+You can specialize the options used to start containers using the `options` definitions:
+
+```yaml
+servers:
+  web:
+    - 192.168.0.1
+    - 192.168.0.2
+  job:
+    hosts:
+      - 192.168.0.3
+      - 192.168.0.4
+    cmd: bin/jobs
+    options:
+      cap-add: true
+      cpu-count: 4
+```
+
+That'll start the job containers with `docker run ... --cap-add --cpu-count 4 ...`.
+
 ### Using remote builder for native multi-arch
 
 If you're developing on ARM64 (like Apple Silicon), but you want to deploy on AMD64 (x86 64-bit), you can use multi-architecture images. By default, MRSK will setup a local buildx configuration that does this through QEMU emulation. But this can be quite slow, especially on the first build.

--- a/lib/mrsk/commands/app.rb
+++ b/lib/mrsk/commands/app.rb
@@ -10,9 +10,9 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
       *role.env_args,
       *config.volume_args,
       *role.label_args,
+      *role.option_args,
       config.absolute_image,
-      role.cmd,
-      *role.cmd_args
+      role.cmd
   end
 
   def start

--- a/lib/mrsk/commands/app.rb
+++ b/lib/mrsk/commands/app.rb
@@ -11,7 +11,8 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
       *config.volume_args,
       *role.label_args,
       config.absolute_image,
-      role.cmd
+      role.cmd,
+      *role.cmd_args
   end
 
   def start

--- a/lib/mrsk/commands/base.rb
+++ b/lib/mrsk/commands/base.rb
@@ -1,6 +1,6 @@
 module Mrsk::Commands
   class Base
-    delegate :redact, :argumentize_for_cmd, to: Mrsk::Utils
+    delegate :redact, to: Mrsk::Utils
 
     MAX_LOG_SIZE = "10m"
 

--- a/lib/mrsk/commands/traefik.rb
+++ b/lib/mrsk/commands/traefik.rb
@@ -1,5 +1,5 @@
 class Mrsk::Commands::Traefik < Mrsk::Commands::Base
-  delegate :argumentize_for_cmd, to: Mrsk::Utils
+  delegate :optionize, to: Mrsk::Utils
 
   CONTAINER_PORT = 80
 
@@ -13,7 +13,7 @@ class Mrsk::Commands::Traefik < Mrsk::Commands::Base
       "traefik",
       "--providers.docker",
       "--log.level=DEBUG",
-      *cmd_args
+      *cmd_option_args
   end
 
   def start
@@ -54,9 +54,9 @@ class Mrsk::Commands::Traefik < Mrsk::Commands::Base
   end
 
   private
-    def cmd_args
+    def cmd_option_args
       if args = config.raw_config.dig(:traefik, "args")
-        argumentize_for_cmd args
+        optionize args
       else
         []
       end

--- a/lib/mrsk/commands/traefik.rb
+++ b/lib/mrsk/commands/traefik.rb
@@ -1,4 +1,6 @@
 class Mrsk::Commands::Traefik < Mrsk::Commands::Base
+  delegate :argumentize_for_cmd, to: Mrsk::Utils
+
   CONTAINER_PORT = 80
 
   def run

--- a/lib/mrsk/configuration/role.rb
+++ b/lib/mrsk/configuration/role.rb
@@ -1,5 +1,5 @@
 class Mrsk::Configuration::Role
-  delegate :argumentize, :argumentize_env_with_secrets, :argumentize_for_cmd, to: Mrsk::Utils
+  delegate :argumentize, :argumentize_env_with_secrets, :optionize, to: Mrsk::Utils
 
   attr_accessor :name
 
@@ -35,9 +35,9 @@ class Mrsk::Configuration::Role
     specializations["cmd"]
   end
 
-  def cmd_args
-    if args = specializations["args"]
-      argumentize_for_cmd args
+  def option_args
+    if args = specializations["options"]
+      optionize args
     else
       []
     end

--- a/lib/mrsk/configuration/role.rb
+++ b/lib/mrsk/configuration/role.rb
@@ -1,5 +1,5 @@
 class Mrsk::Configuration::Role
-  delegate :argumentize, :argumentize_env_with_secrets, to: Mrsk::Utils
+  delegate :argumentize, :argumentize_env_with_secrets, :argumentize_for_cmd, to: Mrsk::Utils
 
   attr_accessor :name
 
@@ -33,6 +33,14 @@ class Mrsk::Configuration::Role
 
   def cmd
     specializations["cmd"]
+  end
+
+  def cmd_args
+    if args = specializations["args"]
+      argumentize_for_cmd args
+    else
+      []
+    end
   end
 
   def running_traefik?

--- a/lib/mrsk/utils.rb
+++ b/lib/mrsk/utils.rb
@@ -23,9 +23,9 @@ module Mrsk::Utils
     end
   end
 
-  # Returns a list of shell-dashed option arguments.
+  # Returns a list of shell-dashed option arguments. If the value is true, it's treated like a value-less option.
   def optionize(args)
-    args.collect { |(key, value)| [ "--#{key}", escape_shell_value(value) ] }.flatten
+    args.collect { |(key, value)| [ "--#{key}", value == true ? nil : escape_shell_value(value) ] }.flatten.compact
   end
 
   # Copied from SSHKit::Backend::Abstract#redact to be available inside Commands classes

--- a/lib/mrsk/utils.rb
+++ b/lib/mrsk/utils.rb
@@ -23,8 +23,8 @@ module Mrsk::Utils
     end
   end
 
-  # Returns a list of shell-dashed arguments to be used to start a command.
-  def argumentize_for_cmd(args)
+  # Returns a list of shell-dashed option arguments.
+  def optionize(args)
     args.collect { |(key, value)| [ "--#{key}", escape_shell_value(value) ] }.flatten
   end
 

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -34,12 +34,12 @@ class CommandsAppTest < ActiveSupport::TestCase
       @app.run.join(" ")
   end
 
-  test "run with cmd args" do
-    @config[:servers] = { "web" => [ "1.1.1.1" ], "jobs" => { "hosts" => [ "1.1.1.2" ], "cmd" => "bin/jobs", "args" => { "mount" => "somewhere" } } }
+  test "run with custom options" do
+    @config[:servers] = { "web" => [ "1.1.1.1" ], "jobs" => { "hosts" => [ "1.1.1.2" ], "cmd" => "bin/jobs", "options" => { "mount" => "somewhere" } } }
     @app = Mrsk::Commands::App.new Mrsk::Configuration.new(@config).tap { |c| c.version = "999" }
 
     assert_equal \
-      "docker run --detach --restart unless-stopped --log-opt max-size=10m --name app-999 -e RAILS_MASTER_KEY=\"456\" --label service=\"app\" --label role=\"jobs\" dhh/app:999 bin/jobs --mount \"somewhere\"",
+      "docker run --detach --restart unless-stopped --log-opt max-size=10m --name app-999 -e RAILS_MASTER_KEY=\"456\" --label service=\"app\" --label role=\"jobs\" --mount \"somewhere\" dhh/app:999 bin/jobs",
       @app.run(role: :jobs).join(" ")
   end
 

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -35,11 +35,11 @@ class CommandsAppTest < ActiveSupport::TestCase
   end
 
   test "run with custom options" do
-    @config[:servers] = { "web" => [ "1.1.1.1" ], "jobs" => { "hosts" => [ "1.1.1.2" ], "cmd" => "bin/jobs", "options" => { "mount" => "somewhere" } } }
+    @config[:servers] = { "web" => [ "1.1.1.1" ], "jobs" => { "hosts" => [ "1.1.1.2" ], "cmd" => "bin/jobs", "options" => { "mount" => "somewhere", "cap-add" => true } } }
     @app = Mrsk::Commands::App.new Mrsk::Configuration.new(@config).tap { |c| c.version = "999" }
 
     assert_equal \
-      "docker run --detach --restart unless-stopped --log-opt max-size=10m --name app-999 -e RAILS_MASTER_KEY=\"456\" --label service=\"app\" --label role=\"jobs\" --mount \"somewhere\" dhh/app:999 bin/jobs",
+      "docker run --detach --restart unless-stopped --log-opt max-size=10m --name app-999 -e RAILS_MASTER_KEY=\"456\" --label service=\"app\" --label role=\"jobs\" --mount \"somewhere\" --cap-add dhh/app:999 bin/jobs",
       @app.run(role: :jobs).join(" ")
   end
 

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -34,6 +34,15 @@ class CommandsAppTest < ActiveSupport::TestCase
       @app.run.join(" ")
   end
 
+  test "run with cmd args" do
+    @config[:servers] = { "web" => [ "1.1.1.1" ], "jobs" => { "hosts" => [ "1.1.1.2" ], "cmd" => "bin/jobs", "args" => { "mount" => "somewhere" } } }
+    @app = Mrsk::Commands::App.new Mrsk::Configuration.new(@config).tap { |c| c.version = "999" }
+
+    assert_equal \
+      "docker run --detach --restart unless-stopped --log-opt max-size=10m --name app-999 -e RAILS_MASTER_KEY=\"456\" --label service=\"app\" --label role=\"jobs\" dhh/app:999 bin/jobs --mount \"somewhere\"",
+      @app.run(role: :jobs).join(" ")
+  end
+
   test "start" do
     assert_equal \
       "docker start app-999",


### PR DESCRIPTION
Allow roles to have their own docker run options. Like:

```yaml
servers:
  web:
    - 1.1.1.1
  jobs:
    hosts:
      - 1.1.1.2
    cmd: bin/jobs
    args:
      mount: "somewhere"
      add-host: true
```

Will result in job containers being started with:

```bash
docker run --detach --restart unless-stopped ... --mount \"somewhere\" --add-host my/app:999 bin/jobs
```