### PR TITLE
Fix syntax error in dependency install step

### DIFF
--- a/lib/mrsk/cli/server.rb
+++ b/lib/mrsk/cli/server.rb
@@ -8,7 +8,7 @@ class Mrsk::Cli::Server < Mrsk::Cli::Base
       end
 
       if dependencies_to_install.any?
-        execute "apt-get update -y && apt-get install #{dependencies_to_install.join(" ")} -y)"
+        execute "apt-get update -y && apt-get install #{dependencies_to_install.join(" ")} -y"
       end
     end
   end


### PR DESCRIPTION
Minor syntax fix for missing opening parenthesis in the dependency install step, run if `curl`/`docker` aren't installed

Test is still passing as it wasn't checking for parenthesis

Running on fresh DigitalOcean Ubuntu 22.04 LTS box with MRSK v0.9.0 I get:

```console
$ bin/mrsk deploy
Ensure curl and Docker are installed...
  INFO [432fcba0] Running which curl on xxx.xxx.xxx.xxx
  INFO [fd30bd5c] Finished in 0.560 seconds with exit status 1 (failed).
  INFO [c324ea51] Running apt-get update -y && apt-get install docker.io -y) on xxx.xxx.xxx.xxx
  Finished all in 3.9 seconds
  ERROR (SSHKit::Command::Failed): apt-get update -y && apt-get install docker.io -y) exit status: 2
apt-get update -y && apt-get install docker.io -y) stdout: Nothing written
apt-get update -y && apt-get install docker.io -y) stderr: bash: -c: line 1: syntax error near unexpected token `)'
bash: -c: line 1: `apt-get update -y && apt-get install docker.io -y)'
```

Cheers!