### PR TITLE
fix: Github Workflow: Docker Publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,10 +17,6 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
-        name: Extract Version Number
-        id: extract_version
-        run: echo "::set-output name=version::${{ github.ref | replace('refs/tags/', '') }}"
-      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       -
@@ -42,4 +38,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/mrsked/mrsk:latest
-            ghcr.io/mrsked/mrsk:${{ steps.extract_version.outputs.version }}
+            ghcr.io/mrsked/mrsk:${{ github.ref_name }}


### PR DESCRIPTION
The workflow was failing with:

```
The workflow is not valid. .github/workflows/docker-publish.yml (Line: 22, Col: 14): Unexpected symbol: '|'. Located at position 12 within expression: github.ref | replace('refs/tags/', '')
```

The `set-output` command is deprecated, so the issue has been fixed by utilising the `github.ref_name` context to retrieve the version tag that triggered the workflow.

> `github.ref_name`: The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown on GitHub. For example, `feature-branch-1`.

https://docs.github.com/en/actions/learn-github-actions/contexts