### PR TITLE
Avoid `[ActiveSupport::OrderedOptions#dig]`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,15 @@ jobs:
           - "2.7"
           - "3.1"
           - "3.2"
+        gemfile:
+          - Gemfile
+          - gemfiles/rails_edge.gemfile
         continue-on-error: [false]
-
     name: ${{ format('Tests (Ruby {0})', matrix.ruby-version) }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.continue-on-error }}
-
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.gem
 coverage/*
 .DS_Store
+gemfiles/*.lock

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,3 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
-
-gem "debug"
-gem "mocha"
-gem "railties"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+git "https://github.com/rails/rails.git" do
+  gem "railties"
+  gem "activesupport"
+end
+
+gemspec path: "../"

--- a/lib/mrsk/commands/traefik.rb
+++ b/lib/mrsk/commands/traefik.rb
@@ -55,7 +55,7 @@ class Mrsk::Commands::Traefik < Mrsk::Commands::Base
 
   private
     def cmd_option_args
-      if args = config.raw_config.dig(:traefik, "args")
+      if args = config.traefik["args"]
         optionize args
       else
         []
@@ -63,6 +63,6 @@ class Mrsk::Commands::Traefik < Mrsk::Commands::Base
     end
 
     def host_port
-      config.raw_config.dig(:traefik, "host_port") || CONTAINER_PORT
+      config.traefik["host_port"] || CONTAINER_PORT
     end
 end

--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -165,6 +165,9 @@ class Mrsk::Configuration
     }.compact
   end
 
+  def traefik
+    raw_config.traefik || {}
+  end
 
   private
     # Will raise ArgumentError if any required config keys are missing

--- a/mrsk.gemspec
+++ b/mrsk.gemspec
@@ -19,4 +19,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "zeitwerk", "~> 2.5"
   spec.add_dependency "ed25519", "~> 1.2"
   spec.add_dependency "bcrypt_pbkdf", "~> 1.0"
+
+  spec.add_development_dependency "debug"
+  spec.add_development_dependency "mocha"
+  spec.add_development_dependency "railties"
 end


### PR DESCRIPTION
The implementation has been updated upstream[^1] to expect symbolized keys. MRSK relies heavily on the fact that nested keys are strings, so we're removing existing uses of `#dig`.

[^1]: https://github.com/rails/rails/commit/5c15b586aab85fc4fa1465499fc9a97a446f4d52
