### PR TITLE
Fix healthcheck test

### DIFF
--- a/test/commands/healthcheck_test.rb
+++ b/test/commands/healthcheck_test.rb
@@ -33,7 +33,7 @@ class CommandsHealthcheckTest < ActiveSupport::TestCase
   test "run with custom options" do
     @config[:servers] = { "web" => { "hosts" => [ "1.1.1.1" ], "options" => { "mount" => "somewhere" } } }
     assert_equal \
-      "docker run --detach --name healthcheck-app-123 --publish 3999:3000 --label service=healthcheck-app --mount \"somewhere\" dhh/app:123",
+      "docker run --detach --name healthcheck-app-123 --publish 3999:3000 --label service=healthcheck-app -e MRSK_CONTAINER_NAME=\"healthcheck-app\" --mount \"somewhere\" dhh/app:123",
       new_command.run.join(" ")
   end
 


### PR DESCRIPTION
Looks like the tests started failing on the options healthcheck PR (#102) after merging the container name env var PR (#104).
