### PR TITLE
Properly pass traefik command options

### DIFF
--- a/lib/mrsk/commands/traefik.rb
+++ b/lib/mrsk/commands/traefik.rb
@@ -56,7 +56,7 @@ class Mrsk::Commands::Traefik < Mrsk::Commands::Base
   private
     def cmd_option_args
       if args = config.traefik["args"]
-        optionize args
+        optionize args, with: "="
       else
         []
       end

--- a/lib/mrsk/utils.rb
+++ b/lib/mrsk/utils.rb
@@ -24,8 +24,14 @@ module Mrsk::Utils
   end
 
   # Returns a list of shell-dashed option arguments. If the value is true, it's treated like a value-less option.
-  def optionize(args)
-    args.collect { |(key, value)| [ "--#{key}", value == true ? nil : escape_shell_value(value) ] }.flatten.compact
+  def optionize(args, with: nil)
+    options = if with
+      args.collect { |(key, value)| value == true ? "--#{key}" : "--#{key}#{with}#{escape_shell_value(value)}" }
+    else
+      args.collect { |(key, value)| [ "--#{key}", value == true ? nil : escape_shell_value(value) ] }
+    end
+
+    options.flatten.compact
   end
 
   # Copied from SSHKit::Backend::Abstract#redact to be available inside Commands classes

--- a/test/commands/traefik_test.rb
+++ b/test/commands/traefik_test.rb
@@ -4,18 +4,18 @@ class CommandsTraefikTest < ActiveSupport::TestCase
   setup do
     @config = {
       service: "app", image: "dhh/app", registry: { "username" => "dhh", "password" => "secret" }, servers: [ "1.1.1.1" ],
-      traefik: { "args" => { "accesslog.format" => "json", "metrics.prometheus.buckets" => "0.1,0.3,1.2,5.0" } }
+      traefik: { "args" => { "accesslog.format" => "json", "api.insecure" => true, "metrics.prometheus.buckets" => "0.1,0.3,1.2,5.0" } }
     }
   end
 
   test "run" do
     assert_equal \
-      "docker run --name traefik --detach --restart unless-stopped --log-opt max-size=10m --publish 80:80 --volume /var/run/docker.sock:/var/run/docker.sock traefik --providers.docker --log.level=DEBUG --accesslog.format \"json\" --metrics.prometheus.buckets \"0.1,0.3,1.2,5.0\"",
+      "docker run --name traefik --detach --restart unless-stopped --log-opt max-size=10m --publish 80:80 --volume /var/run/docker.sock:/var/run/docker.sock traefik --providers.docker --log.level=DEBUG --accesslog.format=\"json\" --api.insecure --metrics.prometheus.buckets=\"0.1,0.3,1.2,5.0\"",
       new_command.run.join(" ")
 
     @config[:traefik]["host_port"] = "8080"
     assert_equal \
-      "docker run --name traefik --detach --restart unless-stopped --log-opt max-size=10m --publish 8080:80 --volume /var/run/docker.sock:/var/run/docker.sock traefik --providers.docker --log.level=DEBUG --accesslog.format \"json\" --metrics.prometheus.buckets \"0.1,0.3,1.2,5.0\"",
+      "docker run --name traefik --detach --restart unless-stopped --log-opt max-size=10m --publish 8080:80 --volume /var/run/docker.sock:/var/run/docker.sock traefik --providers.docker --log.level=DEBUG --accesslog.format=\"json\" --api.insecure --metrics.prometheus.buckets=\"0.1,0.3,1.2,5.0\"",
       new_command.run.join(" ")
   end
 


### PR DESCRIPTION
Traefik command options need to be passed as `--key=value`, not `--key value`.

This will raise an error:

```
$ docker run traefik --entryPoints.web.address ":80"
```

This will not raise an error:

```
$ docker run traefik --entryPoints.web.address=:80
```