### PR TITLE
Add tests for main CLI commands

### DIFF
--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -135,8 +135,10 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
         puts "Binstub already exists in bin/mrsk (remove first to create a new one)"
       else
         puts "Adding MRSK to Gemfile and bundle..."
-        `bundle add mrsk`
-        `bundle binstubs mrsk`
+        run_locally do
+          execute :bundle, :add, :mrsk
+          execute :bundle, :binstubs, :mrsk
+        end
         puts "Created binstub file in bin/mrsk"
       end
     end

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -1,13 +1,16 @@
 require_relative "cli_test_case"
 
 class CliMainTest < CliTestCase
-  test "version" do
-    version = stdouted { Mrsk::Cli::Main.new.version }
-    assert_equal Mrsk::VERSION, version
+  test "setup" do
+    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:server:bootstrap")
+    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:accessory:boot", [ "all" ])
+    Mrsk::Cli::Main.any_instance.expects(:deploy)
+
+    run_command("setup")
   end
 
   test "deploy" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_with_accessories.yml", "skip_broadcast" => false, "skip_push" => false}
+    invoke_options = { "config_file" => "test/fixtures/deploy_with_accessories.yml", "skip_broadcast" => false, "skip_push" => false }
 
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:server:bootstrap", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:registry:login", [], invoke_options)
@@ -93,6 +96,95 @@ class CliMainTest < CliTestCase
     end
   end
 
+  test "details" do
+    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:traefik:details")
+    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:details")
+    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:accessory:details", [ "all" ])
+
+    run_command("details")
+  end
+
+  test "audit" do
+    run_command("audit").tap do |output|
+      assert_match /tail -n 50 mrsk-app-audit.log on 1.1.1.1/, output
+      assert_match /App Host: 1.1.1.1/, output
+      assert_match /tail -n 50 mrsk-app-audit.log on 1.1.1.2/, output
+      assert_match /App Host: 1.1.1.2/, output
+    end
+  end
+
+  test "config" do
+    run_command("config").tap do |output|
+      config = YAML.load(output)
+
+      assert_equal ["web"], config[:roles]
+      assert_equal ["1.1.1.1", "1.1.1.2"], config[:hosts]
+      assert_equal "999", config[:version]
+      assert_equal "dhh/app", config[:repository]
+      assert_equal "dhh/app:999", config[:absolute_image]
+      assert_equal "app-999", config[:service_with_version]
+    end
+  end
+
+  test "init" do
+    Pathname.any_instance.expects(:exist?).returns(false).twice
+    FileUtils.stubs(:mkdir_p)
+    FileUtils.stubs(:cp_r)
+
+    run_command("init").tap do |output|
+      assert_match /Created configuration file in config\/deploy.yml/, output
+      assert_match /Created \.env file/, output
+    end
+  end
+
+  test "init with existing config" do
+    Pathname.any_instance.expects(:exist?).returns(true).twice
+
+    run_command("init").tap do |output|
+      assert_match /Config file already exists in config\/deploy.yml \(remove first to create a new one\)/, output
+    end
+  end
+
+  test "init with bundle option" do
+    Pathname.any_instance.expects(:exist?).returns(false).times(3)
+    FileUtils.stubs(:mkdir_p)
+    FileUtils.stubs(:cp_r)
+
+    run_command("init", "--bundle").tap do |output|
+      assert_match /Created configuration file in config\/deploy.yml/, output
+      assert_match /Created \.env file/, output
+      assert_match /Adding MRSK to Gemfile and bundle/, output
+      assert_match /bundle add mrsk/, output
+      assert_match /bundle binstubs mrsk/, output
+      assert_match /Created binstub file in bin\/mrsk/, output
+    end
+  end
+
+  test "init with bundle option and existing binstub" do
+    Pathname.any_instance.expects(:exist?).returns(true).times(3)
+    FileUtils.stubs(:mkdir_p)
+    FileUtils.stubs(:cp_r)
+
+    run_command("init", "--bundle").tap do |output|
+      assert_match /Config file already exists in config\/deploy.yml \(remove first to create a new one\)/, output
+      assert_match /Binstub already exists in bin\/mrsk \(remove first to create a new one\)/, output
+    end
+  end
+
+  test "envify" do
+    File.expects(:read).with(".env.erb").returns("HELLO=<%= 'world' %>")
+    File.expects(:write).with(".env", "HELLO=world", perm: 0600)
+
+    run_command("envify")
+  end
+
+  test "envify with destination" do
+    File.expects(:read).with(".env.staging.erb").returns("HELLO=<%= 'world' %>")
+    File.expects(:write).with(".env.staging", "HELLO=world", perm: 0600)
+
+    run_command("envify", "-d", "staging")
+  end
+
   test "remove with confirmation" do
     run_command("remove", "-y").tap do |output|
       assert_match /docker container stop traefik/, output
@@ -115,6 +207,11 @@ class CliMainTest < CliTestCase
 
       assert_match /docker logout/, output
     end
+  end
+
+  test "version" do
+    version = stdouted { Mrsk::Cli::Main.new.version }
+    assert_equal Mrsk::VERSION, version
   end
 
   private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,11 +9,11 @@ require "mrsk"
 
 ActiveSupport::LogSubscriber.logger = ActiveSupport::Logger.new(STDOUT) if ENV["VERBOSE"]
 
-# Applies to remote commands only,
-# see https://github.com/capistrano/sshkit/blob/master/lib/sshkit/dsl.rb#L9
+# Applies to remote commands only.
 SSHKit.config.backend = SSHKit::Backend::Printer
 
-# Ensure local commands use the printer backend too
+# Ensure local commands use the printer backend too.
+# See https://github.com/capistrano/sshkit/blob/master/lib/sshkit/dsl.rb#L9
 module SSHKit
   module DSL
     def run_locally(&block)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,18 @@ require "mrsk"
 
 ActiveSupport::LogSubscriber.logger = ActiveSupport::Logger.new(STDOUT) if ENV["VERBOSE"]
 
+# Applies to remote commands only,
+# see https://github.com/capistrano/sshkit/blob/master/lib/sshkit/dsl.rb#L9
 SSHKit.config.backend = SSHKit::Backend::Printer
+
+# Ensure local commands use the printer backend too
+module SSHKit
+  module DSL
+    def run_locally(&block)
+      SSHKit::Backend::Printer.new(SSHKit::Host.new(:local), &block).run
+    end
+  end
+end
 
 class ActiveSupport::TestCase
 end


### PR DESCRIPTION
This adds tests for all CLI commands in `cli/main.rb`. 

It also includes a monkey-patch for `SSHKit` to make `run_locally` use the printer backend too as `SSHKit.config.backend` only applies to remote commands. The backend for `run_locally` is [hard coded](https://github.com/capistrano/sshkit/blob/master/lib/sshkit/dsl.rb#L9).

I'm happy to open additional PRs to test more of the (sub)commands. I just want to make sure this is the way to go.