### PR TITLE
Minor: Properly require active_support

### DIFF
--- a/lib/mrsk.rb
+++ b/lib/mrsk.rb
@@ -1,6 +1,7 @@
 module Mrsk
 end
 
+require "active_support"
 require "zeitwerk"
 
 loader = Zeitwerk::Loader.for_gem


### PR DESCRIPTION
I wanted to give a try at https://github.com/mrsked/mrsk/pull/99 so I ran `mrsk init --bundle' and pointed the gem at this PR
In the same Gemfile I'm running rails latest and got hit by this error:

```
$ bundle exec mrsk version
bundler: failed to load command: mrsk (/home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/bin/mrsk)
/home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/bundler/gems/rails-96fa75e32140/activesupport/lib/active_support/core_ext/time/conversions.rb:62:in `<class:Time>': undefined method `deprecator' for ActiveSupport:Module (NoMethodError)

  deprecate to_default_s: :to_s, deprecator: ActiveSupport.deprecator
                                                          ^^^^^^^^^^^
Did you mean?  deprecate_constant
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/bundler/gems/rails-96fa75e32140/activesupport/lib/active_support/core_ext/time/conversions.rb:7:in `<top (required)>'
	from <internal:/home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/kernel.rb:38:in `require'
	from /home/ylecuyer/Projects/mrsk/lib/mrsk/commands/auditor.rb:1:in `<top (required)>'
	from <internal:/home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/kernel.rb:30:in `require'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/loader/helpers.rb:135:in `const_get'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/loader/helpers.rb:135:in `cget'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/loader/eager_load.rb:169:in `block in actual_eager_load_dir'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/loader/helpers.rb:40:in `block in ls'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/loader/helpers.rb:25:in `each'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/loader/helpers.rb:25:in `ls'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/loader/eager_load.rb:164:in `actual_eager_load_dir'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/loader/eager_load.rb:17:in `block (2 levels) in eager_load'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/loader/eager_load.rb:16:in `each'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/loader/eager_load.rb:16:in `block in eager_load'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/loader/eager_load.rb:10:in `synchronize'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/loader/eager_load.rb:10:in `eager_load'
	from /home/ylecuyer/Projects/mrsk/lib/mrsk.rb:9:in `<top (required)>'
	from <internal:/home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /home/ylecuyer/Projects/mrsk/bin/mrsk:6:in `<top (required)>'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/bin/mrsk:25:in `load'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/bin/mrsk:25:in `<top (required)>'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `load'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `kernel_load'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/bundler/cli/exec.rb:23:in `run'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/bundler/cli.rb:491:in `exec'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/bundler/cli.rb:34:in `dispatch'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/bundler/cli.rb:28:in `start'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/libexec/bundle:45:in `block in <top (required)>'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/3.2.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
	from /home/ylecuyer/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/libexec/bundle:33:in `<top (required)>'
	from /home/ylecuyer/.rbenv/versions/3.2.1/bin/bundle:25:in `load'
	from /home/ylecuyer/.rbenv/versions/3.2.1/bin/bundle:25:in `<main>'
```

Afaiu from the doc https://guides.rubyonrails.org/active_support_core_extensions.html we first need to require active_support before requiring extensions one by one so I simply added the require and it now works properly with latest rails version.

```
$ bundle info rails
  * rails (7.1.0.alpha 96fa75e)
...
$ bundle exec mrsk version
0.9.1
```