### PR TITLE
Fix ActiveSupport::XmlMini::IsolatedExecutionState Name Error

### DIFF
--- a/lib/mrsk.rb
+++ b/lib/mrsk.rb
@@ -1,3 +1,4 @@
+require "active_support"
 module Mrsk
 end
 


### PR DESCRIPTION
While running `mrsk init --bundle'` or `mrsk init` is producing below error right now.

![image](https://user-images.githubusercontent.com/77604504/225568086-83b841df-a4f6-4d02-ac7c-aadd78ab297f.png)

The solution was to explicitly require `active_support` before requiring the zeitwerk core extensions. This is the suggested approach given in the [Active Support documentation][1], but presumably the previous combination of Ruby and Rails was more forgiving of its omittance.

This change is based on the solution identified here:
[rails issue](https://github.com/rails/rails/issues/43851#issuecomment-1001921207
)
[1]: [stand-alone-active-support](https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support
)