### PR TITLE
Add hint to use Docker Hub access tokens

### DIFF
--- a/lib/mrsk/cli/templates/deploy.yml
+++ b/lib/mrsk/cli/templates/deploy.yml
@@ -13,6 +13,8 @@ registry:
   # Specify the registry server, if you're not using Docker Hub
   # server: registry.digitalocean.com / ghcr.io / ...
   username: my-user
+  # When using Docker Hub MRSK_REGISTRY_PASSWORD must be set to a 
+  # Docker Hub access token NOT your account password
   password:
     - MRSK_REGISTRY_PASSWORD
 


### PR DESCRIPTION
Adding a hint to use Docker Hub access tokens instead of the Docker Hub user account password.

I specified my Docker Hub user account password in the .env file and mrsk failed with the following message:

    ERROR (SSHKit::Command::Failed): docker exit status: 256
    docker stdout: Nothing written
    docker stderr: WARNING! Using --password via the CLI is insecure. Use --password-stdin.
    Error response from daemon: Get "https://registry-1.docker.io/v2/": unauthorized: incorrect username or password

I resolved the issue by creating a Docker Hub access token and specifying the access token in the .env file:

   MRSK_REGISTRY_PASSWORD=my-docker-hub-access-token

Adding the comment might save any newbies like me to run into the same error.