### PR TITLE
Remove accessory images using tags rather than labels

### DIFF
--- a/lib/mrsk/commands/accessory.rb
+++ b/lib/mrsk/commands/accessory.rb
@@ -100,7 +100,7 @@ class Mrsk::Commands::Accessory < Mrsk::Commands::Base
   end
 
   def remove_image
-    docker :image, :prune, "--all", "--force", *service_filter
+    docker :image, :rm, "--force", image
   end
 
   private

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -126,7 +126,7 @@ class CliAccessoryTest < CliTestCase
   end
 
   test "remove_image" do
-    assert_match "docker image prune --all --force --filter label=service=app-mysql", run_command("remove_image", "mysql")
+    assert_match "docker image rm --force mysql", run_command("remove_image", "mysql")
   end
 
   test "remove_service_directory" do

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -235,12 +235,12 @@ class CliMainTest < CliTestCase
 
       assert_match /docker container stop app-mysql/, output
       assert_match /docker container prune --force --filter label=service=app-mysql/, output
-      assert_match /docker image prune --all --force --filter label=service=app-mysql/, output
+      assert_match /docker image rm --force mysql/, output
       assert_match /rm -rf app-mysql/, output
 
       assert_match /docker container stop app-redis/, output
       assert_match /docker container prune --force --filter label=service=app-redis/, output
-      assert_match /docker image prune --all --force --filter label=service=app-redis/, output
+      assert_match /docker image rm --force redis/, output
       assert_match /rm -rf app-redis/, output
 
       assert_match /docker logout/, output

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -137,7 +137,7 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
 
   test "remove image" do
     assert_equal \
-      "docker image prune --all --force --filter label=service=app-mysql",
+      "docker image rm --force private.registry/mysql:8.0",
       @mysql.remove_image.join(" ")
   end
 end


### PR DESCRIPTION
Accessory images are removed with `docker image prune` and a label filter currently, but accessory images are not labeled like app images, so no images are actually removed.

Fix by removing the tagged image, which prunes untagged parents.