### PR TITLE
Accessories aren't required to publish a port

### DIFF
--- a/lib/mrsk/commands/accessory.rb
+++ b/lib/mrsk/commands/accessory.rb
@@ -1,6 +1,6 @@
 class Mrsk::Commands::Accessory < Mrsk::Commands::Base
   attr_reader :accessory_config
-  delegate :service_name, :image, :host, :port, :files, :directories, :env_args, :volume_args, :label_args, to: :accessory_config
+  delegate :service_name, :image, :host, :port, :files, :directories, :publish_args, :env_args, :volume_args, :label_args, to: :accessory_config
 
   def initialize(config, name:)
     super(config)
@@ -13,7 +13,7 @@ class Mrsk::Commands::Accessory < Mrsk::Commands::Base
       "--detach",
       "--restart", "unless-stopped",
       "--log-opt", "max-size=#{MAX_LOG_SIZE}",
-      "--publish", port,
+      *publish_args,
       *env_args,
       *volume_args,
       *label_args,

--- a/lib/mrsk/configuration/accessory.rb
+++ b/lib/mrsk/configuration/accessory.rb
@@ -20,11 +20,13 @@ class Mrsk::Configuration::Accessory
   end
 
   def port
-    if specifics["port"].to_s.include?(":")
-      specifics["port"]
-    else
-      "#{specifics["port"]}:#{specifics["port"]}"
+    if port = specifics["port"]&.to_s
+      port.include?(":") ? port : "#{port}:#{port}"
     end
+  end
+
+  def publish_args
+    argumentize "--publish", port if port
   end
 
   def labels

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -32,13 +32,18 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
           "volumes" => [
             "/var/lib/redis:/data"
           ]
+        },
+        "busybox" => {
+          "image" => "busybox:latest",
+          "host" => "1.1.1.7"
         }
       }
     }
 
-    @config = Mrsk::Configuration.new(@config)
-    @mysql  = Mrsk::Commands::Accessory.new(@config, name: :mysql)
-    @redis  = Mrsk::Commands::Accessory.new(@config, name: :redis)
+    @config  = Mrsk::Configuration.new(@config)
+    @mysql   = Mrsk::Commands::Accessory.new(@config, name: :mysql)
+    @redis   = Mrsk::Commands::Accessory.new(@config, name: :redis)
+    @busybox = Mrsk::Commands::Accessory.new(@config, name: :busybox)
 
     ENV["MYSQL_ROOT_PASSWORD"] = "secret123"
   end
@@ -55,6 +60,10 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
     assert_equal \
       "docker run --name app-redis --detach --restart unless-stopped --log-opt max-size=10m --publish 6379:6379 -e SOMETHING=\"else\" --volume /var/lib/redis:/data --label service=\"app-redis\" --label cache=\"true\" redis:latest",
       @redis.run.join(" ")
+
+    assert_equal \
+      "docker run --name app-busybox --detach --restart unless-stopped --log-opt max-size=10m --label service=\"app-busybox\" busybox:latest",
+      @busybox.run.join(" ")
   end
 
   test "start" do


### PR DESCRIPTION
Allows for background accessories like schedulers that don't act as typical network service dependencies and have no port to expose.