### PR TITLE
Add cache-from option

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,16 @@ RUN --mount=type=secret,id=GITHUB_TOKEN \
   rm -rf /usr/local/bundle/cache
 ```
 
+### Using cache at image build
+
+Specifying a Docker tag allows you to use the cache to save container build time:
+
+```yaml
+builder:
+  cache_from:
+    - latest # 37s/hey:latest
+```
+
 ### Using command arguments for Traefik
 
 You can customize the traefik command line:

--- a/lib/mrsk/commands/builder/base.rb
+++ b/lib/mrsk/commands/builder/base.rb
@@ -11,7 +11,7 @@ class Mrsk::Commands::Builder::Base < Mrsk::Commands::Base
   end
 
   def build_options
-    [ *build_tags, *build_labels, *build_args, *build_secrets, *build_dockerfile ]
+    [ *build_tags, *build_labels, *build_args, *build_secrets, *build_cache_from, *build_dockerfile ]
   end
 
   def build_context
@@ -35,6 +35,10 @@ class Mrsk::Commands::Builder::Base < Mrsk::Commands::Base
       argumentize "--secret", secrets.collect { |secret| [ "id", secret ] }
     end
 
+    def build_cache_from
+      argumentize "--cache-from", cache_from_tags.collect { |tag| "#{config.repository}:#{tag}" }
+    end
+
     def build_dockerfile
       argumentize "--file", dockerfile
     end
@@ -45,6 +49,10 @@ class Mrsk::Commands::Builder::Base < Mrsk::Commands::Base
 
     def secrets
       (config.builder && config.builder["secrets"]) || []
+    end
+
+    def cache_from_tags
+      (config.builder && config.builder["cache_from"]) || []
     end
 
     def dockerfile

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -86,6 +86,13 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       builder.push.join(" ")
   end
 
+  test "build cache_from" do
+    builder = new_builder_command(builder: { "cache_from" => ["master", "1.0.0"] })
+    assert_equal \
+      "-t dhh/app:123 -t dhh/app:latest --label service=\"app\" --cache-from dhh/app:master --cache-from dhh/app:1.0.0 --file Dockerfile",
+      builder.target.build_options.join(" ")
+  end
+
   private
     def new_builder_command(additional_config = {})
       Mrsk::Commands::Builder.new(Mrsk::Configuration.new(@config.merge(additional_config), version: "123"))


### PR DESCRIPTION
Allowing the option `--cache_from` to the builder in this PR will reduce the time to build the Docker image.

https://lipanski.com/posts/speed-up-your-docker-builds-with-cache-from