### PR TITLE
Push <image>:latest in addition to <image>:<git-ref>

### DIFF
--- a/lib/mrsk/commands/builder/native.rb
+++ b/lib/mrsk/commands/builder/native.rb
@@ -10,7 +10,8 @@ class Mrsk::Commands::Builder::Native < Mrsk::Commands::Builder::Base
   def push
     combine \
       docker(:build, *build_options, build_context),
-      docker(:push, config.absolute_image)
+      docker(:push, config.absolute_image),
+      docker(:push, config.latest_image)
   end
 
   def info

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -17,7 +17,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "multiarch" => false })
     assert_equal "native", builder.name
     assert_equal \
-      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . && docker push dhh/app:123",
+      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . && docker push dhh/app:123 && docker push dhh/app:latest",
       builder.push.join(" ")
   end
 
@@ -68,7 +68,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
   test "native push with build args" do
     builder = new_builder_command(builder: { "multiarch" => false, "args" => { "a" => 1, "b" => 2 } })
     assert_equal \
-      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\" --file Dockerfile . && docker push dhh/app:123",
+      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\" --file Dockerfile . && docker push dhh/app:123 && docker push dhh/app:latest",
       builder.push.join(" ")
   end
 
@@ -82,7 +82,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
   test "native push with with build secrets" do
     builder = new_builder_command(builder: { "multiarch" => false, "secrets" => [ "a", "b" ] })
     assert_equal \
-      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --secret id=\"a\" --secret id=\"b\" --file Dockerfile . && docker push dhh/app:123",
+      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --secret id=\"a\" --secret id=\"b\" --file Dockerfile . && docker push dhh/app:123 && docker push dhh/app:latest",
       builder.push.join(" ")
   end
 


### PR DESCRIPTION
https://github.com/mrsked/mrsk/commit/1ed4a37da2b73125c37044d04e5a9a5ba0efd62a introduced pulling `<image>:latest` in addition to `<image>:<git-ref>`:

https://github.com/mrsked/mrsk/blob/cec82ac641056dce1718f4cbdc99edcd8bc97484/lib/mrsk/commands/builder/base.rb#L8-L11

As we're not pushing `<image>:latest`:

https://github.com/mrsked/mrsk/blob/cec82ac641056dce1718f4cbdc99edcd8bc97484/lib/mrsk/commands/builder/native.rb#L10-L14

… we're getting an error when trying to deploy:

```
ERROR (SSHKit::Command::Failed): docker exit status: 1
docker stdout: Nothing written
docker stderr: Error response from daemon: manifest for <registry>/<project>/<app>:latest not found: manifest unknown: manifest unknown
```

So this PR adds pushing `<image>:latest`.