### PR TITLE
Rolify app logs cli/command

### DIFF
--- a/lib/mrsk/cli/app.rb
+++ b/lib/mrsk/cli/app.rb
@@ -143,12 +143,11 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
       run_locally do
         info "Following logs on #{MRSK.primary_host}..."
 
-        roles = MRSK.roles_on(MRSK.primary_host)
+        MRSK.specific_roles ||= ["web"]
+        role = MRSK.roles_on(MRSK.primary_host).first
 
-        roles.each do |role|
-          info MRSK.app(role: role).follow_logs(host: MRSK.primary_host, grep: grep)
-          exec MRSK.app(role: role).follow_logs(host: MRSK.primary_host, grep: grep)
-        end
+        info MRSK.app(role: role).follow_logs(host: MRSK.primary_host, grep: grep)
+        exec MRSK.app(role: role).follow_logs(host: MRSK.primary_host, grep: grep)
       end
     else
       since = options[:since]

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -103,16 +103,16 @@ class CliAppTest < CliTestCase
 
   test "logs" do
     SSHKit::Backend::Abstract.any_instance.stubs(:exec)
-      .with("ssh -t root@1.1.1.1 'docker ps --quiet --filter label=service=app | xargs docker logs --timestamps --tail 10 2>&1'")
+      .with("ssh -t root@1.1.1.1 'docker ps --quiet --filter label=service=app --filter label=role=web | xargs docker logs --timestamps --tail 10 2>&1'")
 
-    assert_match "docker ps --quiet --filter label=service=app | xargs docker logs --tail 100 2>&1", run_command("logs")
+    assert_match "docker ps --quiet --filter label=service=app --filter label=role=web | xargs docker logs --tail 100 2>&1", run_command("logs")
   end
 
   test "logs with follow" do
     SSHKit::Backend::Abstract.any_instance.stubs(:exec)
-      .with("ssh -t root@1.1.1.1 'docker ps --quiet --filter label=service=app | xargs docker logs --timestamps --tail 10 --follow 2>&1'")
+      .with("ssh -t root@1.1.1.1 'docker ps --quiet --filter label=service=app --filter label=role=web | xargs docker logs --timestamps --tail 10 --follow 2>&1'")
 
-    assert_match "docker ps --quiet --filter label=service=app | xargs docker logs --timestamps --tail 10 --follow 2>&1", run_command("logs", "--follow")
+    assert_match "docker ps --quiet --filter label=service=app --filter label=role=web | xargs docker logs --timestamps --tail 10 --follow 2>&1", run_command("logs", "--follow")
   end
 
   test "version" do


### PR DESCRIPTION
App logs filtered by roles (e.g., `mrsk app logs --roles=job`) are not filtered correctly.
Also, logs are not output properly when the same service runs on the same host with different roles.

When config/deploy.yml is
```yaml
service: app

servers:
  web:
    - 1.1.1.1
  job:
    hosts:
      - 1.1.1.1
    cmd: bin/jobs
```

current output of `mrsk app logs` is
```bash
INFO [b92537f1] Running docker ps --quiet --filter label=service=app | xargs docker logs --tail 100 2>&1 on 1.1.1.1
App Host: 1.1.1.1
Nothing found
```