### PR TITLE
Set proper exit code on failure

### DIFF
--- a/bin/mrsk
+++ b/bin/mrsk
@@ -10,7 +10,9 @@ begin
 rescue SSHKit::Runner::ExecuteError => e
   puts "  \e[31mERROR (#{e.cause.class}): #{e.cause.message}\e[0m"
   puts e.cause.backtrace if ENV["VERBOSE"]
+  exit 1
 rescue => e
   puts "  \e[31mERROR (#{e.class}): #{e.message}\e[0m"
   puts e.backtrace if ENV["VERBOSE"]
+  exit 1
 end


### PR DESCRIPTION
Currently, when a command fails (e.g. because there is a deploy lock, `ERROR (Mrsk::Cli::Base::LockError): Deploy lock found`), the exit code of the `mrsk` command is `0`. This PR changes this so the exit code is `1` on failure.

Related: #139 