### PR TITLE
Check if env_template exists before envify runs

### DIFF
--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -165,12 +165,12 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
       env_path          = ".env"
     end
 
-    unless File.file?(env_path)
-      puts "#{env_template_path} file does not exist."
-      return
+    if File.file?(env_path)
+      File.write(env_path, ERB.new(File.read(env_template_path)).result, perm: 0600)
+    else
+      puts "#{env_template_path} file does not exist"
     end
 
-    File.write(env_path, ERB.new(File.read(env_template_path)).result, perm: 0600)
   end
 
   desc "remove", "Remove Traefik, app, accessories, and registry session from servers"

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -165,10 +165,10 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
       env_path          = ".env"
     end
 
-    if File.file?(env_path)
+    if File.file?(env_template_path)
       File.write(env_path, ERB.new(File.read(env_template_path)).result, perm: 0600)
     else
-      puts "#{env_template_path} file does not exist"
+      puts "#{env_template_path} does not exist"
     end
 
   end

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -165,6 +165,11 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
       env_path          = ".env"
     end
 
+    unless File.file?(env_path)
+      puts "#{env_template_path} file does not exist."
+      return
+    end
+
     File.write(env_path, ERB.new(File.read(env_template_path)).result, perm: 0600)
   end
 

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -210,13 +210,21 @@ class CliMainTest < CliTestCase
   end
 
   test "envify" do
+    File.expects(:file?).returns(true)
     File.expects(:read).with(".env.erb").returns("HELLO=<%= 'world' %>")
     File.expects(:write).with(".env", "HELLO=world", perm: 0600)
 
     run_command("envify")
   end
 
+  test "envify without template_path" do
+    run_command("envify").tap do |output|
+      assert_equal ".env.erb file does not exist.", output
+    end
+  end
+
   test "envify with destination" do
+    File.expects(:file?).returns(true)
     File.expects(:read).with(".env.staging.erb").returns("HELLO=<%= 'world' %>")
     File.expects(:write).with(".env.staging", "HELLO=world", perm: 0600)
 

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -219,7 +219,7 @@ class CliMainTest < CliTestCase
 
   test "envify without template_path" do
     run_command("envify").tap do |output|
-      assert_equal ".env.erb file does not exist.", output
+      assert_equal ".env.erb does not exist", output
     end
   end
 


### PR DESCRIPTION
At the moment, if the `mrsk envify` is run when `env.erb` file does not exist, the CLI throws Ruby error:
> $ mrsk envify
> ERROR (Errno::ENOENT): No such file or directory @ rb_sysopen - .env.erb

With this change, Mrsk will first check if the env template file exists and then either continue or print a helpful error message.