### PR TITLE
Clear stale containers

### DIFF
--- a/lib/mrsk/cli/app.rb
+++ b/lib/mrsk/cli/app.rb
@@ -22,7 +22,7 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
                 execute *MRSK.app(role: role).rename_container(version: version, new_version: tmp_version)
               end
 
-              old_version = capture_with_info(*MRSK.app(role: role).current_running_version).strip
+              old_version = capture_with_info(*MRSK.app(role: role).current_running_version, raise_on_non_zero_exit: false).strip
               execute *MRSK.app(role: role).run
               sleep MRSK.config.readiness_delay
               execute *MRSK.app(role: role).stop(version: old_version), raise_on_non_zero_exit: false if old_version.present?
@@ -260,7 +260,7 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
 
     def list_versions(host:, role: nil, status: nil)
       versions = nil
-      on(host) { versions = capture_with_info(*MRSK.app(role: role).list_versions(status: status)).split("\n").map(&:strip) }
+      on(host) { versions = capture_with_info(*MRSK.app(role: role).list_versions(status: status), raise_on_non_zero_exit: false).split("\n").map(&:strip) }
       versions
     end
 

--- a/lib/mrsk/cli/app.rb
+++ b/lib/mrsk/cli/app.rb
@@ -134,13 +134,7 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
         roles = MRSK.roles_on(host)
 
         roles.each do |role|
-          stale_versions = \
-            capture_with_info(*MRSK.app(role: role).list_versions, raise_on_non_zero_exit: false)
-            .split("\n")
-            .map(&:strip)
-            .drop(1)
-
-          stale_versions.each do |version|
+          stale_versions(role: role).each do |version|
             if stop
               puts_by_host host, "Stopping stale container for role #{role} with version #{version}"
               execute *MRSK.app(role: role).stop(version: version), raise_on_non_zero_exit: false

--- a/lib/mrsk/cli/app.rb
+++ b/lib/mrsk/cli/app.rb
@@ -136,7 +136,7 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
         roles = MRSK.roles_on(host)
 
         roles.each do |role|
-          cli.stale_versions(host: host, role: role).each do |version|
+          cli.send(:stale_versions, host: host, role: role).each do |version|
             if stop
               puts_by_host host, "Stopping stale container for role #{role} with version #{version}"
               execute *MRSK.app(role: role).stop(version: version), raise_on_non_zero_exit: false
@@ -244,19 +244,6 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
     on(MRSK.hosts) { |host| puts_by_host host, capture_with_info(*MRSK.app.current_running_version).strip }
   end
 
-  no_commands do
-    def stale_versions(host:, role:)
-      versions = nil
-      on(host) do
-        versions = \
-          capture_with_info(*MRSK.app(role: role).list_versions, raise_on_non_zero_exit: false)
-          .split("\n")
-          .drop(1)
-      end
-      versions
-    end
-  end
-
   private
     def using_version(new_version)
       if new_version
@@ -276,6 +263,17 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
       version = nil
       on(host) { version = capture_with_info(*MRSK.app.current_running_version).strip }
       version.presence
+    end
+
+    def stale_versions(host:, role:)
+      versions = nil
+      on(host) do
+        versions = \
+          capture_with_info(*MRSK.app(role: role).list_versions, raise_on_non_zero_exit: false)
+          .split("\n")
+          .drop(1)
+      end
+      versions
     end
 
     def version_or_latest

--- a/lib/mrsk/cli/app.rb
+++ b/lib/mrsk/cli/app.rb
@@ -54,7 +54,7 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
   end
 
   desc "stop", "Stop app container on servers"
-  option :only_old, aliases: "-o", type: :boolean, default: false, desc: "Stop only old containers"
+  option :only_old, aliases: "-o", type: :boolean, default: false, desc: "Stop only old versions containers"
   def stop
     with_lock do
       MRSK.hosts.each do |host|

--- a/lib/mrsk/cli/app.rb
+++ b/lib/mrsk/cli/app.rb
@@ -125,7 +125,7 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
   end
 
   desc "stale_containers", "Detect app stale containers"
-  option :stop, aliases: "-s", type: :boolean, default: false, desc: "Stop the stale containers found."
+  option :stop, aliases: "-s", type: :boolean, default: false, desc: "Stop the stale containers found"
   def stale_containers
     with_lock do
       stop = options[:stop]

--- a/lib/mrsk/cli/app.rb
+++ b/lib/mrsk/cli/app.rb
@@ -246,14 +246,14 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
 
   no_commands do
     def stale_versions(host:, role:)
-      stale_versions = nil
+      versions = nil
       on(host) do
-        stale_versions = \
+        versions = \
           capture_with_info(*MRSK.app(role: role).list_versions, raise_on_non_zero_exit: false)
           .split("\n")
           .drop(1)
       end
-      stale_versions
+      versions
     end
   end
 

--- a/lib/mrsk/cli/app.rb
+++ b/lib/mrsk/cli/app.rb
@@ -142,10 +142,10 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
 
           stale_versions.each do |version|
             if stop
-              puts_by_host host, "Stopping stale container with version #{version}"
+              puts_by_host host, "Stopping stale container for role #{role} with version #{version}"
               execute *MRSK.app(role: role).stop(version: version), raise_on_non_zero_exit: false
             else
-              puts_by_host host,  "Detected stale container with version #{version} (use `mrsk app stale_containers --stop` to stop)"
+              puts_by_host host,  "Detected stale container for role #{role} with version #{version} (use `mrsk app stale_containers --stop` to stop)"
             end
           end
         end

--- a/lib/mrsk/cli/app.rb
+++ b/lib/mrsk/cli/app.rb
@@ -244,15 +244,17 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
     on(MRSK.hosts) { |host| puts_by_host host, capture_with_info(*MRSK.app.current_running_version).strip }
   end
 
-  def stale_versions(host:, role:)
-    stale_versions = nil
-    on(host) do
-      stale_versions = \
-        capture_with_info(*MRSK.app(role: role).list_versions, raise_on_non_zero_exit: false)
-        .split("\n")
-        .drop(1)
+  no_commands do
+    def stale_versions(host:, role:)
+      stale_versions = nil
+      on(host) do
+        stale_versions = \
+          capture_with_info(*MRSK.app(role: role).list_versions, raise_on_non_zero_exit: false)
+          .split("\n")
+          .drop(1)
+      end
+      stale_versions
     end
-    stale_versions
   end
 
   private

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -37,9 +37,6 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
         say "Ensure app can pass healthcheck...", :magenta
         invoke "mrsk:cli:healthcheck:perform", [], invoke_options
 
-        say "Stop old containers...", :magenta
-        invoke "mrsk:cli:app:stop", [], invoke_options.merge({ "only_old" => true })
-
         invoke "mrsk:cli:app:boot", [], invoke_options
 
         say "Prune old containers and images...", :magenta
@@ -67,9 +64,6 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
 
         say "Ensure app can pass healthcheck...", :magenta
         invoke "mrsk:cli:healthcheck:perform", [], invoke_options
-
-        say "Stop old containers...", :magenta
-        invoke "mrsk:cli:app:stop", [], invoke_options.merge({ "only_old" => true })
 
         invoke "mrsk:cli:app:boot", [], invoke_options
       end

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -37,6 +37,9 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
         say "Ensure app can pass healthcheck...", :magenta
         invoke "mrsk:cli:healthcheck:perform", [], invoke_options
 
+        say "Stop stale containers...", :magenta
+        invoke "mrsk:cli:app:stop_stale_containers", [], invoke_options
+
         invoke "mrsk:cli:app:boot", [], invoke_options
 
         say "Prune old containers and images...", :magenta
@@ -64,6 +67,9 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
 
         say "Ensure app can pass healthcheck...", :magenta
         invoke "mrsk:cli:healthcheck:perform", [], invoke_options
+
+        say "Stop stale containers...", :magenta
+        invoke "mrsk:cli:app:stop_stale_containers", [], invoke_options
 
         invoke "mrsk:cli:app:boot", [], invoke_options
       end

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -37,8 +37,8 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
         say "Ensure app can pass healthcheck...", :magenta
         invoke "mrsk:cli:healthcheck:perform", [], invoke_options
 
-        say "Stop stale containers...", :magenta
-        invoke "mrsk:cli:app:stop_stale_containers", [], invoke_options
+        say "Stop old containers...", :magenta
+        invoke "mrsk:cli:app:stop", [], invoke_options.merge({ "only_old" => true })
 
         invoke "mrsk:cli:app:boot", [], invoke_options
 
@@ -68,8 +68,8 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
         say "Ensure app can pass healthcheck...", :magenta
         invoke "mrsk:cli:healthcheck:perform", [], invoke_options
 
-        say "Stop stale containers...", :magenta
-        invoke "mrsk:cli:app:stop_stale_containers", [], invoke_options
+        say "Stop old containers...", :magenta
+        invoke "mrsk:cli:app:stop", [], invoke_options.merge({ "only_old" => true })
 
         invoke "mrsk:cli:app:boot", [], invoke_options
       end

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -37,6 +37,9 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
         say "Ensure app can pass healthcheck...", :magenta
         invoke "mrsk:cli:healthcheck:perform", [], invoke_options
 
+        say "Detect stale containers...", :magenta
+        invoke "mrsk:cli:app:stale_containers", [], invoke_options
+
         invoke "mrsk:cli:app:boot", [], invoke_options
 
         say "Prune old containers and images...", :magenta
@@ -64,6 +67,9 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
 
         say "Ensure app can pass healthcheck...", :magenta
         invoke "mrsk:cli:healthcheck:perform", [], invoke_options
+
+        say "Detect stale containers...", :magenta
+        invoke "mrsk:cli:app:stale_containers", [], invoke_options
 
         invoke "mrsk:cli:app:boot", [], invoke_options
       end

--- a/lib/mrsk/commands/app.rb
+++ b/lib/mrsk/commands/app.rb
@@ -97,7 +97,8 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
   def list_versions(*docker_args, status: nil)
     pipe \
       docker(:ps, *filter_args(status: status), *docker_args, "--format", '"{{.Names}}"'),
-      %(grep -oE "\\-[^-]+$"), # Extract SHA from "service-role-dest-SHA"
+      # Extract SHA from "service-role-dest-SHA"
+      %(grep -oE "\\-[^-]+$"), 
       %(cut -c 2-)
   end
 

--- a/lib/mrsk/commands/app.rb
+++ b/lib/mrsk/commands/app.rb
@@ -97,7 +97,8 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
   def list_versions(*docker_args, status: nil)
     pipe \
       docker(:ps, *filter_args(status: status), *docker_args, "--format", '"{{.Names}}"'),
-      %(grep -oP "(?<=\-)[^-]+$") # Extract SHA from "service-role-dest-SHA"
+      %(grep -oE "\\-[^-]+$"), # Extract SHA from "service-role-dest-SHA"
+      %(cut -c 2-)
   end
 
   def list_containers

--- a/lib/mrsk/commands/app.rb
+++ b/lib/mrsk/commands/app.rb
@@ -97,8 +97,7 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
   def list_versions(*docker_args, status: nil)
     pipe \
       docker(:ps, *filter_args(status: status), *docker_args, "--format", '"{{.Names}}"'),
-      # Extract SHA from "service-role-dest-SHA"
-      %(grep -oE "\\-[^-]+$"), 
+      %(grep -oE "\\-[^-]+$"), # Extract SHA from "service-role-dest-SHA"
       %(cut -c 2-)
   end
 

--- a/lib/mrsk/sshkit_with_ext.rb
+++ b/lib/mrsk/sshkit_with_ext.rb
@@ -1,7 +1,17 @@
 require "sshkit"
 require "sshkit/dsl"
 
+module AppHelper
+  def stale_versions(role:)
+    capture_with_info(*MRSK.app(role: role).list_versions, raise_on_non_zero_exit: false)
+      .split("\n")
+      .drop(1)
+  end
+end
+
 class SSHKit::Backend::Abstract
+  include AppHelper
+
   def capture_with_info(*args, **kwargs)
     capture(*args, **kwargs, verbosity: Logger::INFO)
   end

--- a/lib/mrsk/sshkit_with_ext.rb
+++ b/lib/mrsk/sshkit_with_ext.rb
@@ -2,8 +2,8 @@ require "sshkit"
 require "sshkit/dsl"
 
 class SSHKit::Backend::Abstract
-  def capture_with_info(*args)
-    capture(*args, verbosity: Logger::INFO)
+  def capture_with_info(*args, **kwargs)
+    capture(*args, **kwargs, verbosity: Logger::INFO)
   end
 
   def puts_by_host(host, output, type: "App")

--- a/lib/mrsk/sshkit_with_ext.rb
+++ b/lib/mrsk/sshkit_with_ext.rb
@@ -1,17 +1,7 @@
 require "sshkit"
 require "sshkit/dsl"
 
-module AppHelper
-  def stale_versions(role:)
-    capture_with_info(*MRSK.app(role: role).list_versions, raise_on_non_zero_exit: false)
-      .split("\n")
-      .drop(1)
-  end
-end
-
 class SSHKit::Backend::Abstract
-  include AppHelper
-
   def capture_with_info(*args, **kwargs)
     capture(*args, **kwargs, verbosity: Logger::INFO)
   end

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -48,13 +48,12 @@ class CliAppTest < CliTestCase
     end
   end
 
-  test "stop_stale_containers" do
+  test "stop only old containers" do
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :ps, "--filter", "label=service=app", "--filter", "label=role=web", "--format", "\"{{.Names}}\"", "|", "grep -oE \"\\-[^-]+$\"", "|", "cut -c 2-", raise_on_non_zero_exit: false)
       .returns("12345678\n87654321")
 
-    run_command("stop_stale_containers").tap do |output|
-      assert_match /Stopping stale container with version 87654321/, output
+    run_command("stop", '--only-old').tap do |output|
       assert_match /#{Regexp.escape("docker container ls --all --filter name=^app-web-87654321$ --quiet | xargs docker stop")}/, output
     end
   end

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -19,7 +19,7 @@ class CliAppTest < CliTestCase
       .returns("12345678") # running version
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
-      .with(:docker, :ps, "--filter", "label=service=app", "--filter", "label=role=web", "--filter", "status=running", "--latest", "--format", "\"{{.Names}}\"", "|", "grep -oP \"(?<=-)[^-]+$\"")
+      .with(:docker, :ps, "--filter", "label=service=app", "--filter", "label=role=web", "--filter", "status=running", "--latest", "--format", "\"{{.Names}}\"", "|", "grep -oE \"\\-[^-]+$\"", "|", "cut -c 2-", raise_on_non_zero_exit: false)
       .returns("123") # old version
 
     run_command("boot").tap do |output|
@@ -40,7 +40,7 @@ class CliAppTest < CliTestCase
 
   test "stop" do
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
-      .with(:docker, :ps, "--filter", "label=service=app", "--filter", "label=role=web", "--format", "\"{{.Names}}\"", "|", "grep -oP \"(?<=-)[^-]+$\"")
+      .with(:docker, :ps, "--filter", "label=service=app", "--filter", "label=role=web", "--format", "\"{{.Names}}\"", "|", "grep -oE \"\\-[^-]+$\"", "|", "cut -c 2-", raise_on_non_zero_exit: false)
       .returns("12345678")
 
     run_command("stop").tap do |output|
@@ -50,7 +50,7 @@ class CliAppTest < CliTestCase
 
   test "stop_stale_containers" do
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
-      .with(:docker, :ps, "--filter", "label=service=app", "--filter", "label=role=web", "--format", "\"{{.Names}}\"", "|", "grep -oP \"(?<=-)[^-]+$\"")
+      .with(:docker, :ps, "--filter", "label=service=app", "--filter", "label=role=web", "--format", "\"{{.Names}}\"", "|", "grep -oE \"\\-[^-]+$\"", "|", "cut -c 2-", raise_on_non_zero_exit: false)
       .returns("12345678\n87654321")
 
     run_command("stop_stale_containers").tap do |output|
@@ -67,7 +67,7 @@ class CliAppTest < CliTestCase
 
   test "remove" do
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
-      .with(:docker, :ps, "--filter", "label=service=app", "--filter", "label=role=web", "--format", "\"{{.Names}}\"", "|", "grep -oP \"(?<=-)[^-]+$\"")
+      .with(:docker, :ps, "--filter", "label=service=app", "--filter", "label=role=web", "--format", "\"{{.Names}}\"", "|", "grep -oE \"\\-[^-]+$\"", "|", "cut -c 2-", raise_on_non_zero_exit: false)
       .returns("12345678")
 
     run_command("remove").tap do |output|
@@ -103,7 +103,7 @@ class CliAppTest < CliTestCase
 
   test "exec with reuse" do
     run_command("exec", "--reuse", "ruby -v").tap do |output|
-      assert_match "docker ps --filter label=service=app --filter status=running --format \"{{.Names}}\" | grep -oP \"(?<=-)[^-]+$\"", output # Get current version
+      assert_match "docker ps --filter label=service=app --filter status=running --format \"{{.Names}}\" | grep -oE \"\\-[^-]+$\" | cut -c 2-", output # Get current version
       assert_match "docker exec app-web-999 ruby -v", output
     end
   end
@@ -136,14 +136,14 @@ class CliAppTest < CliTestCase
 
   test "version" do
     run_command("version").tap do |output|
-      assert_match "docker ps --filter label=service=app --filter status=running --latest --format \"{{.Names}}\" | grep -oP \"(?<=-)[^-]+$\"", output
+      assert_match "docker ps --filter label=service=app --filter status=running --latest --format \"{{.Names}}\" | grep -oE \"\\-[^-]+$\" | cut -c 2-", output
     end
   end
 
 
   test "version through main" do
     stdouted { Mrsk::Cli::Main.start(["app", "version", "-c", "test/fixtures/deploy_with_accessories.yml", "--hosts", "1.1.1.1"]) }.tap do |output|
-      assert_match "docker ps --filter label=service=app --filter status=running --latest --format \"{{.Names}}\" | grep -oP \"(?<=-)[^-]+$\"", output
+      assert_match "docker ps --filter label=service=app --filter status=running --latest --format \"{{.Names}}\" | grep -oE \"\\-[^-]+$\" | cut -c 2-", output
     end
   end
 

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -50,7 +50,7 @@ class CliAppTest < CliTestCase
       .returns("12345678\n87654321")
 
     run_command("stale_containers").tap do |output|
-      assert_match /Detected stale container with version 87654321/, output
+      assert_match /Detected stale container for role web with version 87654321/, output
     end
   end
 
@@ -60,7 +60,7 @@ class CliAppTest < CliTestCase
       .returns("12345678\n87654321")
 
     run_command("stale_containers", "--stop").tap do |output|
-      assert_match /Stopping stale container with version 87654321/, output
+      assert_match /Stopping stale container for role web with version 87654321/, output
       assert_match /#{Regexp.escape("docker container ls --all --filter name=^app-web-87654321$ --quiet | xargs docker stop")}/, output
     end
   end

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -17,7 +17,6 @@ class CliMainTest < CliTestCase
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:build:deliver", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:traefik:boot", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:healthcheck:perform", [], invoke_options)
-    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stop", [], invoke_options.merge({ "only_old" => true }))
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:boot", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:prune:all", [], invoke_options)
 
@@ -27,7 +26,6 @@ class CliMainTest < CliTestCase
       assert_match /Build and push app image/, output
       assert_match /Ensure Traefik is running/, output
       assert_match /Ensure app can pass healthcheck/, output
-      assert_match /Stop old containers/, output
       assert_match /Prune old containers and images/, output
     end
   end
@@ -40,7 +38,6 @@ class CliMainTest < CliTestCase
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:build:pull", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:traefik:boot", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:healthcheck:perform", [], invoke_options)
-    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stop", [], invoke_options.merge({ "only_old" => true }))
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:boot", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:prune:all", [], invoke_options)
 
@@ -51,7 +48,6 @@ class CliMainTest < CliTestCase
       assert_match /Pull app image/, output
       assert_match /Ensure Traefik is running/, output
       assert_match /Ensure app can pass healthcheck/, output
-      assert_match /Stop old containers/, output
       assert_match /Prune old containers and images/, output
       assert_match /Releasing the deploy lock/, output
     end
@@ -62,7 +58,6 @@ class CliMainTest < CliTestCase
 
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:build:deliver", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:healthcheck:perform", [], invoke_options)
-    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stop", [], invoke_options.merge({ "only_old" => true }))
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:boot", [], invoke_options)
 
     run_command("redeploy").tap do |output|
@@ -76,7 +71,6 @@ class CliMainTest < CliTestCase
 
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:build:pull", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:healthcheck:perform", [], invoke_options)
-    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stop", [], invoke_options.merge({ "only_old" => true }))
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:boot", [], invoke_options)
 
     run_command("redeploy", "--skip_push").tap do |output|

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -17,7 +17,7 @@ class CliMainTest < CliTestCase
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:build:deliver", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:traefik:boot", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:healthcheck:perform", [], invoke_options)
-    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stop_stale_containers", [], invoke_options)
+    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stop", [], invoke_options.merge({ "only_old" => true }))
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:boot", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:prune:all", [], invoke_options)
 
@@ -27,7 +27,7 @@ class CliMainTest < CliTestCase
       assert_match /Build and push app image/, output
       assert_match /Ensure Traefik is running/, output
       assert_match /Ensure app can pass healthcheck/, output
-      assert_match /Stop stale containers/, output
+      assert_match /Stop old containers/, output
       assert_match /Prune old containers and images/, output
     end
   end
@@ -40,7 +40,7 @@ class CliMainTest < CliTestCase
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:build:pull", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:traefik:boot", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:healthcheck:perform", [], invoke_options)
-    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stop_stale_containers", [], invoke_options)
+    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stop", [], invoke_options.merge({ "only_old" => true }))
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:boot", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:prune:all", [], invoke_options)
 
@@ -51,7 +51,7 @@ class CliMainTest < CliTestCase
       assert_match /Pull app image/, output
       assert_match /Ensure Traefik is running/, output
       assert_match /Ensure app can pass healthcheck/, output
-      assert_match /Stop stale containers/, output
+      assert_match /Stop old containers/, output
       assert_match /Prune old containers and images/, output
       assert_match /Releasing the deploy lock/, output
     end
@@ -62,7 +62,7 @@ class CliMainTest < CliTestCase
 
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:build:deliver", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:healthcheck:perform", [], invoke_options)
-    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stop_stale_containers", [], invoke_options)
+    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stop", [], invoke_options.merge({ "only_old" => true }))
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:boot", [], invoke_options)
 
     run_command("redeploy").tap do |output|
@@ -76,7 +76,7 @@ class CliMainTest < CliTestCase
 
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:build:pull", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:healthcheck:perform", [], invoke_options)
-    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stop_stale_containers", [], invoke_options)
+    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stop", [], invoke_options.merge({ "only_old" => true }))
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:boot", [], invoke_options)
 
     run_command("redeploy", "--skip_push").tap do |output|

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -96,7 +96,7 @@ class CliMainTest < CliTestCase
 
   test "rollback good version" do
     Mrsk::Cli::Main.any_instance.stubs(:container_name_available?).returns(true)
-    SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info).with(:docker, :ps, "--filter", "label=service=app", "--filter", "status=running", "--latest", "--format", "\"{{.Names}}\"", "|", "grep -oP \"(?<=-)[^-]+$\"").returns("version-to-rollback\n").at_least_once
+    SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info).with(:docker, :ps, "--filter", "label=service=app", "--filter", "status=running", "--latest", "--format", "\"{{.Names}}\"", "|", "grep -oE \"\\-[^-]+$\"", "|", "cut -c 2-").returns("version-to-rollback\n").at_least_once
 
     run_command("rollback", "123", config_file: "deploy_with_accessories").tap do |output|
       assert_match "Start version 123", output
@@ -107,7 +107,7 @@ class CliMainTest < CliTestCase
 
   test "rollback without old version" do
     Mrsk::Cli::Main.any_instance.stubs(:container_name_available?).returns(true)
-    SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info).with(:docker, :ps, "--filter", "label=service=app", "--filter", "status=running", "--latest", "--format", "\"{{.Names}}\"", "|", "grep -oP \"(?<=-)[^-]+$\"").returns("").at_least_once
+    SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info).with(:docker, :ps, "--filter", "label=service=app", "--filter", "status=running", "--latest", "--format", "\"{{.Names}}\"", "|", "grep -oE \"\\-[^-]+$\"", "|", "cut -c 2-").returns("").at_least_once
 
     run_command("rollback", "123").tap do |output|
       assert_match "Start version 123", output
@@ -232,7 +232,7 @@ class CliMainTest < CliTestCase
   test "remove with confirmation" do
     %w[ web workers ].each do |role|
       SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
-        .with(:docker, :ps, "--filter", "label=service=app", "--filter", "label=role=#{role}", "--format", "\"{{.Names}}\"", "|", "grep -oP \"(?<=-)[^-]+$\"")
+        .with(:docker, :ps, "--filter", "label=service=app", "--filter", "label=role=#{role}", "--format", "\"{{.Names}}\"", "|", "grep -oE \"\\-[^-]+$\"", "|", "cut -c 2-", raise_on_non_zero_exit: false)
         .times(2)
         .returns("12345678")
     end

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -17,6 +17,7 @@ class CliMainTest < CliTestCase
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:build:deliver", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:traefik:boot", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:healthcheck:perform", [], invoke_options)
+    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stale_containers", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:boot", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:prune:all", [], invoke_options)
 
@@ -26,6 +27,7 @@ class CliMainTest < CliTestCase
       assert_match /Build and push app image/, output
       assert_match /Ensure Traefik is running/, output
       assert_match /Ensure app can pass healthcheck/, output
+      assert_match /Detect stale containers/, output
       assert_match /Prune old containers and images/, output
     end
   end
@@ -38,6 +40,7 @@ class CliMainTest < CliTestCase
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:build:pull", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:traefik:boot", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:healthcheck:perform", [], invoke_options)
+    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stale_containers", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:boot", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:prune:all", [], invoke_options)
 
@@ -48,6 +51,7 @@ class CliMainTest < CliTestCase
       assert_match /Pull app image/, output
       assert_match /Ensure Traefik is running/, output
       assert_match /Ensure app can pass healthcheck/, output
+      assert_match /Detect stale containers/, output
       assert_match /Prune old containers and images/, output
       assert_match /Releasing the deploy lock/, output
     end
@@ -58,6 +62,7 @@ class CliMainTest < CliTestCase
 
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:build:deliver", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:healthcheck:perform", [], invoke_options)
+    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stale_containers", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:boot", [], invoke_options)
 
     run_command("redeploy").tap do |output|
@@ -71,6 +76,7 @@ class CliMainTest < CliTestCase
 
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:build:pull", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:healthcheck:perform", [], invoke_options)
+    Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:stale_containers", [], invoke_options)
     Mrsk::Cli::Main.any_instance.expects(:invoke).with("mrsk:cli:app:boot", [], invoke_options)
 
     run_command("redeploy", "--skip_push").tap do |output|
@@ -224,19 +230,12 @@ class CliMainTest < CliTestCase
   end
 
   test "remove with confirmation" do
-    %w[ web workers ].each do |role|
-      SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
-        .with(:docker, :ps, "--filter", "label=service=app", "--filter", "label=role=#{role}", "--format", "\"{{.Names}}\"", "|", "grep -oE \"\\-[^-]+$\"", "|", "cut -c 2-", raise_on_non_zero_exit: false)
-        .times(2)
-        .returns("12345678")
-    end
-
     run_command("remove", "-y", config_file: "deploy_with_accessories").tap do |output|
       assert_match /docker container stop traefik/, output
       assert_match /docker container prune --force --filter label=org.opencontainers.image.title=Traefik/, output
       assert_match /docker image prune --all --force --filter label=org.opencontainers.image.title=Traefik/, output
 
-      assert_match "docker container ls --all --filter name=^app-web-12345678$ --quiet | xargs docker stop", output
+      assert_match /docker ps --quiet --filter label=service=app | xargs docker stop/, output
       assert_match /docker container prune --force --filter label=service=app/, output
       assert_match /docker image prune --all --force --filter label=service=app/, output
 

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -199,17 +199,17 @@ class CommandsAppTest < ActiveSupport::TestCase
 
   test "current_running_version" do
     assert_equal \
-      "docker ps --filter label=service=app --filter label=role=web --filter status=running --latest --format \"{{.Names}}\" | grep -oP \"(?<=-)[^-]+$\"",
+      "docker ps --filter label=service=app --filter label=role=web --filter status=running --latest --format \"{{.Names}}\" | grep -oE \"\\-[^-]+$\" | cut -c 2-",
       new_command.current_running_version.join(" ")
   end
 
   test "list_versions" do
     assert_equal \
-      "docker ps --filter label=service=app --filter label=role=web --format \"{{.Names}}\" | grep -oP \"(?<=-)[^-]+$\"",
+      "docker ps --filter label=service=app --filter label=role=web --format \"{{.Names}}\" | grep -oE \"\\-[^-]+$\" | cut -c 2-",
       new_command.list_versions.join(" ")
 
     assert_equal \
-      "docker ps --filter label=service=app --filter label=role=web --filter status=running --latest --format \"{{.Names}}\" | grep -oP \"(?<=-)[^-]+$\"",
+      "docker ps --filter label=service=app --filter label=role=web --filter status=running --latest --format \"{{.Names}}\" | grep -oE \"\\-[^-]+$\" | cut -c 2-",
       new_command.list_versions("--latest", status: :running).join(" ")
   end
 

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -63,14 +63,14 @@ class CommandsAppTest < ActiveSupport::TestCase
 
   test "stop" do
     assert_equal \
-      "docker ps --quiet --filter label=service=app --filter label=role=web | xargs docker stop",
+      "docker ps --quiet --filter label=service=app --filter label=role=web --filter status=running --latest | xargs docker stop",
       new_command.stop.join(" ")
   end
 
   test "stop with custom stop wait time" do
     @config[:stop_wait_time] = 30
     assert_equal \
-      "docker ps --quiet --filter label=service=app --filter label=role=web | xargs docker stop -t 30",
+      "docker ps --quiet --filter label=service=app --filter label=role=web --filter status=running --latest | xargs docker stop -t 30",
       new_command.stop.join(" ")
   end
 
@@ -96,37 +96,37 @@ class CommandsAppTest < ActiveSupport::TestCase
 
   test "logs" do
     assert_equal \
-      "docker ps --quiet --filter label=service=app --filter label=role=web | xargs docker logs 2>&1",
+      "docker ps --quiet --filter label=service=app --filter label=role=web --filter status=running --latest | xargs docker logs 2>&1",
       new_command.logs.join(" ")
 
     assert_equal \
-      "docker ps --quiet --filter label=service=app --filter label=role=web | xargs docker logs --since 5m 2>&1",
+      "docker ps --quiet --filter label=service=app --filter label=role=web --filter status=running --latest | xargs docker logs --since 5m 2>&1",
       new_command.logs(since: "5m").join(" ")
 
     assert_equal \
-      "docker ps --quiet --filter label=service=app --filter label=role=web | xargs docker logs --tail 100 2>&1",
+      "docker ps --quiet --filter label=service=app --filter label=role=web --filter status=running --latest | xargs docker logs --tail 100 2>&1",
       new_command.logs(lines: "100").join(" ")
 
     assert_equal \
-      "docker ps --quiet --filter label=service=app --filter label=role=web | xargs docker logs --since 5m --tail 100 2>&1",
+      "docker ps --quiet --filter label=service=app --filter label=role=web --filter status=running --latest | xargs docker logs --since 5m --tail 100 2>&1",
       new_command.logs(since: "5m", lines: "100").join(" ")
 
     assert_equal \
-      "docker ps --quiet --filter label=service=app --filter label=role=web | xargs docker logs 2>&1 | grep 'my-id'",
+      "docker ps --quiet --filter label=service=app --filter label=role=web --filter status=running --latest | xargs docker logs 2>&1 | grep 'my-id'",
       new_command.logs(grep: "my-id").join(" ")
 
     assert_equal \
-      "docker ps --quiet --filter label=service=app --filter label=role=web | xargs docker logs --since 5m 2>&1 | grep 'my-id'",
+      "docker ps --quiet --filter label=service=app --filter label=role=web --filter status=running --latest | xargs docker logs --since 5m 2>&1 | grep 'my-id'",
       new_command.logs(since: "5m", grep: "my-id").join(" ")
   end
 
   test "follow logs" do
     assert_match \
-      "docker ps --quiet --filter label=service=app --filter label=role=web | xargs docker logs --timestamps --tail 10 --follow 2>&1",
+      "docker ps --quiet --filter label=service=app --filter label=role=web --filter status=running --latest | xargs docker logs --timestamps --tail 10 --follow 2>&1",
       new_command.follow_logs(host: "app-1")
 
     assert_match \
-      "docker ps --quiet --filter label=service=app --filter label=role=web | xargs docker logs --timestamps --tail 10 --follow 2>&1 | grep \"Completed\"",
+      "docker ps --quiet --filter label=service=app --filter label=role=web --filter status=running --latest | xargs docker logs --timestamps --tail 10 --follow 2>&1 | grep \"Completed\"",
       new_command.follow_logs(host: "app-1", grep: "Completed")
   end
 
@@ -178,17 +178,17 @@ class CommandsAppTest < ActiveSupport::TestCase
   end
 
 
-  test "current_container_id" do
+  test "current_running_container_id" do
     assert_equal \
-      "docker ps --quiet --filter label=service=app --filter label=role=web",
-      new_command.current_container_id.join(" ")
+      "docker ps --quiet --filter label=service=app --filter label=role=web --filter status=running --latest",
+      new_command.current_running_container_id.join(" ")
   end
 
-  test "current_container_id with destination" do
+  test "current_running_container_id with destination" do
     @destination = "staging"
     assert_equal \
-      "docker ps --quiet --filter label=service=app --filter label=destination=staging --filter label=role=web",
-      new_command.current_container_id.join(" ")
+      "docker ps --quiet --filter label=service=app --filter label=destination=staging --filter label=role=web --filter status=running --latest",
+      new_command.current_running_container_id.join(" ")
   end
 
   test "container_id_for" do
@@ -199,8 +199,18 @@ class CommandsAppTest < ActiveSupport::TestCase
 
   test "current_running_version" do
     assert_equal \
-      "docker ps --filter label=service=app --filter label=role=web --format \"{{.Names}}\" | sed 's/-/\\n/g' | tail -n 1",
+      "docker ps --filter label=service=app --filter label=role=web --filter status=running --latest --format \"{{.Names}}\" | grep -oP \"(?<=-)[^-]+$\"",
       new_command.current_running_version.join(" ")
+  end
+
+  test "list_versions" do
+    assert_equal \
+      "docker ps --filter label=service=app --filter label=role=web --format \"{{.Names}}\" | grep -oP \"(?<=-)[^-]+$\"",
+      new_command.list_versions.join(" ")
+
+    assert_equal \
+      "docker ps --filter label=service=app --filter label=role=web --filter status=running --latest --format \"{{.Names}}\" | grep -oP \"(?<=-)[^-]+$\"",
+      new_command.list_versions("--latest", status: :running).join(" ")
   end
 
   test "list_containers" do


### PR DESCRIPTION
By stopping all the older containers matching `/#{service}-#{role}-#{dest}-.*/` running on the same host.