### PR TITLE
Add labels to custom command containers

### DIFF
--- a/lib/mrsk/commands/accessory.rb
+++ b/lib/mrsk/commands/accessory.rb
@@ -18,6 +18,7 @@ class Mrsk::Commands::Accessory < Mrsk::Commands::Base
       *env_args,
       *volume_args,
       *label_args,
+      "--label", "custom=false",
       *option_args,
       image,
       cmd
@@ -57,12 +58,14 @@ class Mrsk::Commands::Accessory < Mrsk::Commands::Base
       *command
   end
 
-  def execute_in_new_container(*command, interactive: false)
+  def execute_in_new_container(*command, interactive: false, labels: [])
     docker :run,
       ("-it" if interactive),
       "--rm",
       *env_args,
       *volume_args,
+      "--label", "custom=true",
+      *argumentize("--label", labels),
       image,
       *command
   end
@@ -71,8 +74,8 @@ class Mrsk::Commands::Accessory < Mrsk::Commands::Base
     run_over_ssh execute_in_existing_container(*command, interactive: true)
   end
 
-  def execute_in_new_container_over_ssh(*command)
-    run_over_ssh execute_in_new_container(*command, interactive: true)
+  def execute_in_new_container_over_ssh(*command, labels: [])
+    run_over_ssh execute_in_new_container(*command, interactive: true, labels: labels)
   end
 
   def run_over_ssh(command)

--- a/lib/mrsk/commands/app.rb
+++ b/lib/mrsk/commands/app.rb
@@ -17,7 +17,9 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
       *role.env_args,
       *config.logging_args,
       *config.volume_args,
+      *config.label_args,
       *role.label_args,
+      "--label", "custom=false",
       *role.option_args,
       config.absolute_image,
       role.cmd
@@ -63,12 +65,16 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
       *command
   end
 
-  def execute_in_new_container(*command, interactive: false)
+  def execute_in_new_container(*command, interactive: false, labels: [])
+    role = config.role(self.role)
+
     docker :run,
       ("-it" if interactive),
       "--rm",
       *config.env_args,
       *config.volume_args,
+      "--label", "custom=true",
+      *argumentize("--label", labels),
       config.absolute_image,
       *command
   end
@@ -77,8 +83,8 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
     run_over_ssh execute_in_existing_container(*command, interactive: true), host: host
   end
 
-  def execute_in_new_container_over_ssh(*command, host:)
-    run_over_ssh execute_in_new_container(*command, interactive: true), host: host
+  def execute_in_new_container_over_ssh(*command, host:, labels: [])
+    run_over_ssh execute_in_new_container(*command, interactive: true, labels: labels), host: host
   end
 
 

--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -130,6 +130,9 @@ class Mrsk::Configuration
     end
   end
 
+  def label_args
+    argumentize "--label", { "service" => service, "destination" => destination}.compact
+  end
 
   def ssh_user
     if raw_config.ssh.present?

--- a/lib/mrsk/configuration/role.rb
+++ b/lib/mrsk/configuration/role.rb
@@ -16,7 +16,7 @@ class Mrsk::Configuration::Role
   end
 
   def labels
-    default_labels.merge(traefik_labels).merge(custom_labels)
+    { "role" => name }.merge(traefik_labels).merge(custom_labels)
   end
 
   def label_args
@@ -60,14 +60,6 @@ class Mrsk::Configuration::Role
       else
         servers = config.servers[name]
         servers.is_a?(Array) ? servers : Array(servers["hosts"])
-      end
-    end
-
-    def default_labels
-      if config.destination
-        { "service" => config.service, "role" => name, "destination" => config.destination }
-      else
-        { "service" => config.service, "role" => name }
       end
     end
 

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -78,7 +78,7 @@ class CliAppTest < CliTestCase
 
   test "exec" do
     run_command("exec", "ruby -v").tap do |output|
-      assert_match "docker run --rm dhh/app:latest ruby -v", output
+      assert_match "docker run --rm --label custom=true dhh/app:latest ruby -v", output
     end
   end
 
@@ -86,6 +86,18 @@ class CliAppTest < CliTestCase
     run_command("exec", "--reuse", "ruby -v").tap do |output|
       assert_match "docker ps --filter label=service=app --format \"{{.Names}}\" | sed 's/-/\\n/g' | tail -n 1", output # Get current version
       assert_match "docker exec app-web-999 ruby -v", output
+    end
+  end
+
+  test "exec with labels" do
+    run_command("exec", "ruby -v", "--labels", "hello=world", "abc=def").tap do |output|
+      assert_match "docker run --rm --label custom=true --label hello=world --label abc=def dhh/app:latest ruby -v", output
+    end
+  end
+
+  test "exec with reuse and labels" do
+    assert_raise(ArgumentError) do
+      run_command("exec", "--reuse", "ruby -v", "--labels", "hello=world", "abc=def")
     end
   end
 

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -13,7 +13,7 @@ class CommandsAppTest < ActiveSupport::TestCase
 
   test "run" do
     assert_equal \
-      "docker run --detach --restart unless-stopped --name app-web-999 -e MRSK_CONTAINER_NAME=\"app-web-999\" -e RAILS_MASTER_KEY=\"456\" --log-opt max-size=\"10m\" --label service=\"app\" --label role=\"web\" --label traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\" --label traefik.http.services.app.loadbalancer.healthcheck.path=\"/up\" --label traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\" --label traefik.http.middlewares.app-retry.retry.attempts=\"5\" --label traefik.http.middlewares.app-retry.retry.initialinterval=\"500ms\" --label traefik.http.routers.app.middlewares=\"app-retry@docker\" dhh/app:999",
+      "docker run --detach --restart unless-stopped --name app-web-999 -e MRSK_CONTAINER_NAME=\"app-web-999\" -e RAILS_MASTER_KEY=\"456\" --log-opt max-size=\"10m\" --label service=\"app\" --label role=\"web\" --label traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\" --label traefik.http.services.app.loadbalancer.healthcheck.path=\"/up\" --label traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\" --label traefik.http.middlewares.app-retry.retry.attempts=\"5\" --label traefik.http.middlewares.app-retry.retry.initialinterval=\"500ms\" --label traefik.http.routers.app.middlewares=\"app-retry@docker\" --label custom=false dhh/app:999",
       new_command.run.join(" ")
   end
 
@@ -21,7 +21,7 @@ class CommandsAppTest < ActiveSupport::TestCase
     @config[:volumes] = ["/local/path:/container/path" ]
 
     assert_equal \
-      "docker run --detach --restart unless-stopped --name app-web-999 -e MRSK_CONTAINER_NAME=\"app-web-999\" -e RAILS_MASTER_KEY=\"456\" --log-opt max-size=\"10m\" --volume /local/path:/container/path --label service=\"app\" --label role=\"web\" --label traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\" --label traefik.http.services.app.loadbalancer.healthcheck.path=\"/up\" --label traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\" --label traefik.http.middlewares.app-retry.retry.attempts=\"5\" --label traefik.http.middlewares.app-retry.retry.initialinterval=\"500ms\" --label traefik.http.routers.app.middlewares=\"app-retry@docker\" dhh/app:999",
+      "docker run --detach --restart unless-stopped --name app-web-999 -e MRSK_CONTAINER_NAME=\"app-web-999\" -e RAILS_MASTER_KEY=\"456\" --log-opt max-size=\"10m\" --volume /local/path:/container/path --label service=\"app\" --label role=\"web\" --label traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\" --label traefik.http.services.app.loadbalancer.healthcheck.path=\"/up\" --label traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\" --label traefik.http.middlewares.app-retry.retry.attempts=\"5\" --label traefik.http.middlewares.app-retry.retry.initialinterval=\"500ms\" --label traefik.http.routers.app.middlewares=\"app-retry@docker\" --label custom=false dhh/app:999",
       new_command.run.join(" ")
   end
 
@@ -29,14 +29,14 @@ class CommandsAppTest < ActiveSupport::TestCase
     @config[:healthcheck] = { "path" => "/healthz" }
 
     assert_equal \
-      "docker run --detach --restart unless-stopped --name app-web-999 -e MRSK_CONTAINER_NAME=\"app-web-999\" -e RAILS_MASTER_KEY=\"456\" --log-opt max-size=\"10m\" --label service=\"app\" --label role=\"web\" --label traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\" --label traefik.http.services.app.loadbalancer.healthcheck.path=\"/healthz\" --label traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\" --label traefik.http.middlewares.app-retry.retry.attempts=\"5\" --label traefik.http.middlewares.app-retry.retry.initialinterval=\"500ms\" --label traefik.http.routers.app.middlewares=\"app-retry@docker\" dhh/app:999",
+      "docker run --detach --restart unless-stopped --name app-web-999 -e MRSK_CONTAINER_NAME=\"app-web-999\" -e RAILS_MASTER_KEY=\"456\" --log-opt max-size=\"10m\" --label service=\"app\" --label role=\"web\" --label traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\" --label traefik.http.services.app.loadbalancer.healthcheck.path=\"/healthz\" --label traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\" --label traefik.http.middlewares.app-retry.retry.attempts=\"5\" --label traefik.http.middlewares.app-retry.retry.initialinterval=\"500ms\" --label traefik.http.routers.app.middlewares=\"app-retry@docker\" --label custom=false dhh/app:999",
       new_command.run.join(" ")
   end
 
   test "run with custom options" do
     @config[:servers] = { "web" => [ "1.1.1.1" ], "jobs" => { "hosts" => [ "1.1.1.2" ], "cmd" => "bin/jobs", "options" => { "mount" => "somewhere", "cap-add" => true } } }
     assert_equal \
-      "docker run --detach --restart unless-stopped --name app-jobs-999 -e MRSK_CONTAINER_NAME=\"app-jobs-999\" -e RAILS_MASTER_KEY=\"456\" --log-opt max-size=\"10m\" --label service=\"app\" --label role=\"jobs\" --mount \"somewhere\" --cap-add dhh/app:999 bin/jobs",
+      "docker run --detach --restart unless-stopped --name app-jobs-999 -e MRSK_CONTAINER_NAME=\"app-jobs-999\" -e RAILS_MASTER_KEY=\"456\" --log-opt max-size=\"10m\" --label service=\"app\" --label role=\"jobs\" --label custom=false --mount \"somewhere\" --cap-add dhh/app:999 bin/jobs",
       new_command(role: "jobs").run.join(" ")
   end
 
@@ -44,7 +44,7 @@ class CommandsAppTest < ActiveSupport::TestCase
     @config[:logging] = { "driver" => "local", "options" => { "max-size" => "100m", "max-file" => "3" } }
 
     assert_equal \
-      "docker run --detach --restart unless-stopped --name app-web-999 -e MRSK_CONTAINER_NAME=\"app-web-999\" -e RAILS_MASTER_KEY=\"456\" --log-driver \"local\" --log-opt max-size=\"100m\" --log-opt max-file=\"3\" --label service=\"app\" --label role=\"web\" --label traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\" --label traefik.http.services.app.loadbalancer.healthcheck.path=\"/up\" --label traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\" --label traefik.http.middlewares.app-retry.retry.attempts=\"5\" --label traefik.http.middlewares.app-retry.retry.initialinterval=\"500ms\" --label traefik.http.routers.app.middlewares=\"app-retry@docker\" dhh/app:999",
+      "docker run --detach --restart unless-stopped --name app-web-999 -e MRSK_CONTAINER_NAME=\"app-web-999\" -e RAILS_MASTER_KEY=\"456\" --log-driver \"local\" --log-opt max-size=\"100m\" --log-opt max-file=\"3\" --label service=\"app\" --label role=\"web\" --label traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\" --label traefik.http.services.app.loadbalancer.healthcheck.path=\"/up\" --label traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\" --label traefik.http.middlewares.app-retry.retry.attempts=\"5\" --label traefik.http.middlewares.app-retry.retry.initialinterval=\"500ms\" --label traefik.http.routers.app.middlewares=\"app-retry@docker\" --label custom=false dhh/app:999",
       new_command.run.join(" ")
   end
 
@@ -133,8 +133,14 @@ class CommandsAppTest < ActiveSupport::TestCase
 
   test "execute in new container" do
     assert_equal \
-      "docker run --rm -e RAILS_MASTER_KEY=\"456\" dhh/app:999 bin/rails db:setup",
+      "docker run --rm -e RAILS_MASTER_KEY=\"456\" --label custom=true dhh/app:999 bin/rails db:setup",
       new_command.execute_in_new_container("bin/rails", "db:setup").join(" ")
+  end
+
+  test "execute in new container with labels" do
+    assert_equal \
+      "docker run --rm -e RAILS_MASTER_KEY=\"456\" --label custom=true --label foo=bar --label baz=zab dhh/app:999 bin/rails db:setup",
+      new_command.execute_in_new_container("bin/rails", "db:setup", labels: ["foo=bar", "baz=zab"]).join(" ")
   end
 
   test "execute in existing container" do
@@ -144,8 +150,13 @@ class CommandsAppTest < ActiveSupport::TestCase
   end
 
   test "execute in new container over ssh" do
-    assert_match %r|docker run -it --rm -e RAILS_MASTER_KEY=\"456\" dhh/app:999 bin/rails c|,
+    assert_match %r|docker run -it --rm -e RAILS_MASTER_KEY=\"456\" --label custom=true dhh/app:999 bin/rails c|,
       new_command.execute_in_new_container_over_ssh("bin/rails", "c", host: "app-1")
+  end
+
+  test "execute in new container over ssh with labels" do
+    assert_match %r|docker run -it --rm -e RAILS_MASTER_KEY=\"456\" --label custom=true --label foo=bar --label baz=zab dhh/app:999 bin/rails c|,
+      new_command.execute_in_new_container_over_ssh("bin/rails", "c", host: "app-1", labels: ["foo=bar", "baz=zab"])
   end
 
   test "execute in existing container over ssh" do

--- a/test/configuration/role_test.rb
+++ b/test/configuration/role_test.rb
@@ -38,11 +38,11 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
   end
 
   test "label args" do
-    assert_equal [ "--label", "service=\"app\"", "--label", "role=\"workers\"" ], @config_with_roles.role(:workers).label_args
+    assert_equal [ "--label", "role=\"workers\"" ], @config_with_roles.role(:workers).label_args
   end
 
   test "special label args for web" do
-    assert_equal [ "--label", "service=\"app\"", "--label", "role=\"web\"", "--label", "traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\"", "--label", "traefik.http.services.app.loadbalancer.healthcheck.path=\"/up\"", "--label", "traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\"", "--label", "traefik.http.middlewares.app-retry.retry.attempts=\"5\"", "--label", "traefik.http.middlewares.app-retry.retry.initialinterval=\"500ms\"", "--label", "traefik.http.routers.app.middlewares=\"app-retry@docker\"" ], @config.role(:web).label_args
+    assert_equal [ "--label", "role=\"web\"", "--label", "traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\"", "--label", "traefik.http.services.app.loadbalancer.healthcheck.path=\"/up\"", "--label", "traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\"", "--label", "traefik.http.middlewares.app-retry.retry.attempts=\"5\"", "--label", "traefik.http.middlewares.app-retry.retry.initialinterval=\"500ms\"", "--label", "traefik.http.routers.app.middlewares=\"app-retry@docker\"" ], @config.role(:web).label_args
   end
 
   test "custom labels" do
@@ -66,7 +66,7 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
       c[:servers]["beta"] = { "traefik" => "true", "hosts" => [ "1.1.1.5" ] }
     })
 
-    assert_equal [ "--label", "service=\"app\"", "--label", "role=\"beta\"", "--label", "traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\"", "--label", "traefik.http.services.app.loadbalancer.healthcheck.path=\"/up\"", "--label", "traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\"", "--label", "traefik.http.middlewares.app-retry.retry.attempts=\"5\"", "--label", "traefik.http.middlewares.app-retry.retry.initialinterval=\"500ms\"", "--label", "traefik.http.routers.app.middlewares=\"app-retry@docker\"" ], config.role(:beta).label_args
+    assert_equal [ "--label", "role=\"beta\"", "--label", "traefik.http.routers.app.rule=\"PathPrefix(\\`/\\`)\"", "--label", "traefik.http.services.app.loadbalancer.healthcheck.path=\"/up\"", "--label", "traefik.http.services.app.loadbalancer.healthcheck.interval=\"1s\"", "--label", "traefik.http.middlewares.app-retry.retry.attempts=\"5\"", "--label", "traefik.http.middlewares.app-retry.retry.initialinterval=\"500ms\"", "--label", "traefik.http.routers.app.middlewares=\"app-retry@docker\"" ], config.role(:beta).label_args
   end
 
   test "env overwritten by role" do

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -209,6 +209,18 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal ["--volume", "/local/path:/container/path"], @config.volume_args
   end
 
+  test "label args" do
+    assert_equal ["--label", "service=\"app\""], @config.label_args
+  end
+
+  test "label args with destination" do
+    dest_config_file = Pathname.new(File.expand_path("fixtures/deploy_for_dest.yml", __dir__))
+
+    config = Mrsk::Configuration.create_from config_file: dest_config_file, destination: "world"
+
+    assert_equal ["--label", "service=\"app\"", "--label", "destination=\"world\""], config.label_args
+  end
+
   test "logging args default" do
     assert_equal ["--log-opt", "max-size=\"10m\""], @config.logging_args
   end


### PR DESCRIPTION
Add the --labels (aliased to -l) option to `mrsk app exec` and `mrsk accessory exec`. This allow us to add custom labels to the containers.

Example labels:
- The user who started the container
- Mark containers that we expect to run for a long time
- Add a time by which the command is expected to finish

Labels are passed verbatim to `docker run`.

Additionally adds an `custom` label to all app and accessory containers. The value is true for ones started via `mrsk app|accessory exec` and false otherwise.