### PR TITLE
Add github discussions link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Watch the screencast: https://www.youtube.com/watch?v=LL1cV2FXZ5I
 
 Join us on Discord: https://discord.gg/YgHVT7GCXS
 
+Discss on Github: https://github.com/mrsked/mrsk/discussions
+
 ## Installation
 
 If you have a Ruby environment available, you can install MRSK globally with:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Watch the screencast: https://www.youtube.com/watch?v=LL1cV2FXZ5I
 
 Join us on Discord: https://discord.gg/YgHVT7GCXS
 
-Discss on Github: https://github.com/mrsked/mrsk/discussions
+Ask questions: https://github.com/mrsked/mrsk/discussions
 
 ## Installation
 


### PR DESCRIPTION
I realize that there's a discussions link on github.com but I didn't realize mrsk actually utilized it until I saw it mentioned on Discord. I was thinking adding it to the readme would help push people there.