### PR TITLE
Configurable max_attempts for healthcheck

### DIFF
--- a/lib/mrsk/cli/healthcheck.rb
+++ b/lib/mrsk/cli/healthcheck.rb
@@ -1,5 +1,5 @@
 class Mrsk::Cli::Healthcheck < Mrsk::Cli::Base
-  MAX_ATTEMPTS = 7
+  DEFAULT_MAX_ATTEMPTS = 7
 
   class HealthcheckError < StandardError; end
 
@@ -13,6 +13,7 @@ class Mrsk::Cli::Healthcheck < Mrsk::Cli::Base
 
         target = "Health check against #{MRSK.config.healthcheck["path"]}"
         attempt = 1
+        max_attempts = MRSK.config.healthcheck["max_attempts"] || DEFAULT_MAX_ATTEMPTS
 
         begin
           status = capture_with_info(*MRSK.healthcheck.curl)
@@ -23,7 +24,7 @@ class Mrsk::Cli::Healthcheck < Mrsk::Cli::Base
             raise HealthcheckError, "#{target} failed with status #{status}"
           end
         rescue SSHKit::Command::Failed
-          if attempt <= MAX_ATTEMPTS
+          if attempt <= max_attempts
             info "#{target} failed to respond, retrying in #{attempt}s..."
             sleep attempt
             attempt += 1


### PR DESCRIPTION
Some app frameworks require more time to boot than Rails, for example the framework Grails, which **requires around 15-20 secs** to boot for a simple Grails 5 app (uses Spring Boot)

Adding the max_attempts option to a healthcheck is a way to fix this:

```
healthcheck:
   path: "/job/ping"
   port: 3999
   max_attempts: 30
```

This PR adds that.

The default max attempt of 7 is kept as it originally.

The new **max_attempt** parameter is optional. 