### PR TITLE
Improved deploy lock acquisition

### DIFF
--- a/lib/mrsk/cli.rb
+++ b/lib/mrsk/cli.rb
@@ -1,4 +1,5 @@
 module Mrsk::Cli
+  class LockError < StandardError; end
 end
 
 # SSHKit uses instance eval, so we need a global const for ergonomics

--- a/lib/mrsk/cli/lock.rb
+++ b/lib/mrsk/cli/lock.rb
@@ -12,7 +12,7 @@ class Mrsk::Cli::Lock < Mrsk::Cli::Base
     message = options[:message]
     handle_missing_lock do
       on(MRSK.primary_host) { execute *MRSK.lock.acquire(message, MRSK.config.version) }
-      say "Set the deploy lock"
+      say "Acquired the deploy lock"
     end
   end
 
@@ -20,7 +20,7 @@ class Mrsk::Cli::Lock < Mrsk::Cli::Base
   def release
     handle_missing_lock do
       on(MRSK.primary_host) { execute *MRSK.lock.release }
-      say "Removed the deploy lock"
+      say "Released the deploy lock"
     end
   end
 

--- a/test/cli/cli_test_case.rb
+++ b/test/cli/cli_test_case.rb
@@ -22,4 +22,8 @@ class CliTestCase < ActiveSupport::TestCase
     def stdouted
       capture(:stdout) { yield }.strip
     end
-end
+
+    def stderred
+      capture(:stderr) { yield }.strip
+    end
+  end


### PR DESCRIPTION
1. Don't raise lock error for non-lock issues during acquire (see https://github.com/mrsked/mrsk/pull/181)
2. If there is an error while the lock is held, don't release the lock and send a warning to stderr