### PR TITLE
Require net-ssh ~> 7.0 for SHA-2 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       bcrypt_pbkdf (~> 1.0)
       dotenv (~> 2.8)
       ed25519 (~> 1.2)
+      net-ssh (~> 7.0)
       sshkit (~> 1.21)
       thor (~> 1.2)
       zeitwerk (~> 2.5)

--- a/mrsk.gemspec
+++ b/mrsk.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport", ">= 7.0"
   spec.add_dependency "sshkit", "~> 1.21"
+  spec.add_dependency "net-ssh", "~> 7.0"
   spec.add_dependency "thor", "~> 1.2"
   spec.add_dependency "dotenv", "~> 2.8"
   spec.add_dependency "zeitwerk", "~> 2.5"


### PR DESCRIPTION
This PR adds a version requirement for the net-ssh gem of ~> 7.0.

Versions of net-ssh prior to 7 do not support the SHA-2 algorithm for RSA client authentication (see https://github.com/net-ssh/net-ssh/blob/master/CHANGES.txt#L21), which will prevent mrsk from connecting to host machines using those keys. In some cases this presented as mrsk being unable to acquire a lock, and in others it was an authentication failure (depending on whether mrsk was trying to execute a command or acquire a lock for further work).

mrsk already requires sshkit, which has a version requirement of net-ssh >= 2.8.0. In many cases, this works well, as the latest version of net-ssh would likely get installed anyway. In some cases where an application uses net-ssh and specifies its own version requirement of  >= 2.8.0 and < 7, and uses a SHA-2 key to connect to the host, both mrsk and sshkit would be fine (the bundle version requirements would all succeed), but net-ssh would fail to open a connection and mrsk would fail with one of the issues above.

Please let me know if there's anything else I can do for this PR!

Fixes #180.