### PR TITLE
Labels can be added to Traefik

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,21 @@ traefik:
 
 This starts the Traefik container with `--volume /tmp/example.json:/tmp/example.json --publish 8080:8080 --memory 512m` arguments to `docker run`.
 
+### Traefik container lables
+
+Add labels to Traefik Docker container.
+
+```yaml
+traefik:
+  lables:
+    - traefik.enable: true
+    - traefik.http.routers.dashboard.rule: Host(`traefik.example.com`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))
+    - traefik.http.routers.dashboard.service: api@internal
+    - traefik.http.routers.dashboard.middlewares: auth
+    - traefik.http.middlewares.auth.basicauth.users: test:$2y$05$H2o72tMaO.TwY1wNQUV1K.fhjRgLHRDWohFvUZOJHBEtUXNKrqUKi # test:password
+```
+
+This labels Traefik container with `--label traefik.http.routers.dashboard.middlewares=\"auth\"` and so on.
 
 ### Traefik alternate entrypoints
 

--- a/lib/mrsk/commands/traefik.rb
+++ b/lib/mrsk/commands/traefik.rb
@@ -1,5 +1,5 @@
 class Mrsk::Commands::Traefik < Mrsk::Commands::Base
-  delegate :optionize, to: Mrsk::Utils
+  delegate :argumentize, :optionize, to: Mrsk::Utils
 
   DEFAULT_IMAGE = "traefik:v2.9"
   CONTAINER_PORT = 80
@@ -11,6 +11,7 @@ class Mrsk::Commands::Traefik < Mrsk::Commands::Base
       "--publish", port,
       "--volume", "/var/run/docker.sock:/var/run/docker.sock",
       *config.logging_args,
+      *label_args,
       *docker_options_args,
       image,
       "--providers.docker",
@@ -56,6 +57,14 @@ class Mrsk::Commands::Traefik < Mrsk::Commands::Base
   end
 
   private
+    def label_args
+      argumentize "--label", labels
+    end
+
+    def labels
+      config.traefik["labels"] || []
+    end
+
     def image
       config.traefik.fetch("image") { DEFAULT_IMAGE }
     end

--- a/test/commands/traefik_test.rb
+++ b/test/commands/traefik_test.rb
@@ -54,6 +54,17 @@ class CommandsTraefikTest < ActiveSupport::TestCase
       new_command.run.join(" ")
   end
 
+  test "run with labels configured" do
+    assert_equal \
+      "docker run --name traefik --detach --restart unless-stopped --publish 80:80 --volume /var/run/docker.sock:/var/run/docker.sock --log-opt max-size=\"10m\" #{@image} --providers.docker --log.level=DEBUG --accesslog.format=\"json\" --api.insecure --metrics.prometheus.buckets=\"0.1,0.3,1.2,5.0\"",
+      new_command.run.join(" ")
+
+    @config[:traefik]["labels"] = { "traefik.http.routers.dashboard.service" => "api@internal", "traefik.http.routers.dashboard.middlewares" => "auth" }
+    assert_equal \
+      "docker run --name traefik --detach --restart unless-stopped --publish 80:80 --volume /var/run/docker.sock:/var/run/docker.sock --log-opt max-size=\"10m\" --label traefik.http.routers.dashboard.service=\"api@internal\" --label traefik.http.routers.dashboard.middlewares=\"auth\" #{@image} --providers.docker --log.level=DEBUG --accesslog.format=\"json\" --api.insecure --metrics.prometheus.buckets=\"0.1,0.3,1.2,5.0\"",
+      new_command.run.join(" ")
+  end
+
   test "run without configuration" do
     @config.delete(:traefik)
 


### PR DESCRIPTION
If we need to configure the Traefik container with labels, we need the option to attach labels to the Traefik container itself. 

For example, we need this configure secure dashboard for Traefik as described in Traefik docs:
https://doc.traefik.io/traefik/operations/dashboard/#dashboard-router-rule