### PR TITLE
Pull the primary host from the role

### DIFF
--- a/lib/mrsk/commander.rb
+++ b/lib/mrsk/commander.rb
@@ -35,7 +35,7 @@ class Mrsk::Commander
   end
 
   def primary_host
-    specific_hosts&.first || config.primary_web_host
+    specific_hosts&.first || specific_roles&.first&.primary_host || config.primary_web_host
   end
 
   def roles

--- a/test/commander_test.rb
+++ b/test/commander_test.rb
@@ -47,8 +47,8 @@ class CommanderTest < ActiveSupport::TestCase
   end
 
   test "primary_host with specific hosts via role" do
-    @mrsk.specific_roles = "web"
-    assert_equal "1.1.1.1", @mrsk.primary_host
+    @mrsk.specific_roles = "workers"
+    assert_equal "1.1.1.3", @mrsk.primary_host
   end
 
   test "roles_on" do


### PR DESCRIPTION
So commands like this run on a host with the specified role:
```
mrsk app exec -r=console -i "/bin/bash`
mrsk app logs -f -r=workers
```