### PR TITLE
Add OpenSSH Client to the MRSK docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY Gemfile Gemfile.lock mrsk.gemspec ./
 COPY lib/mrsk/version.rb /mrsk/lib/mrsk/version.rb
 
 # Install system dependencies
-RUN apk add --no-cache --update build-base git docker openrc \
+RUN apk add --no-cache --update build-base git docker openrc openssh-client-default \
     && rc-update add docker boot \
     && gem install bundler --version=2.4.3 \
     && bundle install


### PR DESCRIPTION
* Some actions (like `mrsk app logs --follow` ) are running the command `ssh`  locally.
* The docker image build by MRSK does not include `ssh`, so those actions fail.

This PR solves that by adding the openssh-client to the image during build.