### PR TITLE
load environment variables from multiple .env files as dotenv-rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ MRSK_REGISTRY_PASSWORD=pw
 DB_PASSWORD=secret123
 ```
 
+environment variables will override in the following order (highest defined variable overrides lower):
+
+| Hierarchy Priority | Filename                   | Should I `.gitignore`it?                            | Notes                                                        |
+| ------------------ | -------------------------- | --------------------------------------------------- | ------------------------------------------------------------ |
+| 1st (highest)      | `.env.[destination].local` | Yes!                                                | Local overrides of destination-specific settings.             |
+| 1st                | `.env.[destination]`       | Depends                                             | Declared destination-specific settings.                       |
+| 1st                | `.env.deploy.local`        | Yes!                                                | Local overrides of deploy-specific settings.                  |
+| 2nd                | `.env.local`               | Definitely.                                          | Local overrides of settings                                  |
+| 3rd                | `.env.deploy`              | Depends                                             | Declared deploy-specific settings                             |
+| Last               | `.env`                     | Depends                                             | The Original®                                                |
+
+> NOTE: this priority is based on the order in which [dotenv loads the files](https://github.com/bkeepers/dotenv/blob/master/README.md#what-other-env-files-can-i-use).
+
 ### Using a generated .env file
 
 #### 1Password as a secret store

--- a/lib/mrsk/cli/base.rb
+++ b/lib/mrsk/cli/base.rb
@@ -30,11 +30,17 @@ module Mrsk::Cli
 
     private
       def load_envs
+        env_files = [
+          ".env.deploy.local",
+          ".env.local",
+          ".env.deploy",
+          ".env"
+        ]
         if destination = options[:destination]
-          Dotenv.load(".env.#{destination}", ".env")
-        else
-          Dotenv.load(".env")
+          env_files.unshift(".env.#{destination}")
+          env_files.unshift(".env.#{destination}.local")
         end
+        Dotenv.load(*env_files)
       end
 
       def options_with_subcommand_class_options


### PR DESCRIPTION
Almost all of our projects are loading environment variables with dotenv-rails, so we always commit `.env` file to Git, our developers clone repository and create `.env.local` to override database/redis settings

I think mrsk can follow the best practice of dotenv-rails, not only read `.env` file, but also another files in priority as: 

1. .env.`[destination]`.local
2. .env.`[destination]`
3. .env.deploy.local
4. .env.local
5. .env.deploy
6. .env