### PR TITLE
Add optional healthcheck skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,11 +686,14 @@ healthcheck:
   path: /healthz
   port: 4000
   max_attempts: 7
+  skip: false
 ```
 
 This will ensure your application is configured with a traefik label for the healthcheck against `/healthz` and that the pre-deploy healthcheck that MRSK performs is done against the same path on port 4000.
 
 The healthcheck also allows for an optional `max_attempts` setting, which will attempt the healthcheck up to the specified number of times before failing the deploy. This is useful for applications that take a while to start up. The default is 7.
+
+Optional setting `skip` can be useful for deploying bots (Discord bots, Twitch bots, regular jobs) or anything that does not require an incoming HTTP connection. The default is false.
 
 ## Commands
 

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -34,8 +34,12 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
         say "Ensure Traefik is running...", :magenta
         invoke "mrsk:cli:traefik:boot", [], invoke_options
 
-        say "Ensure app can pass healthcheck...", :magenta
-        invoke "mrsk:cli:healthcheck:perform", [], invoke_options
+				if MRSK.config.healthcheck["skip"]
+					say "Skipping healthcheck...", :magenta
+				else
+					say "Ensure app can pass healthcheck...", :magenta
+					invoke "mrsk:cli:healthcheck:perform", [], invoke_options
+				end
 
         say "Detect stale containers...", :magenta
         invoke "mrsk:cli:app:stale_containers", [], invoke_options
@@ -67,8 +71,12 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
           invoke "mrsk:cli:build:deliver", [], invoke_options
         end
 
-        say "Ensure app can pass healthcheck...", :magenta
-        invoke "mrsk:cli:healthcheck:perform", [], invoke_options
+				if MRSK.config.healthcheck["skip"]
+					say "Skipping healthcheck...", :magenta
+				else
+					say "Ensure app can pass healthcheck...", :magenta
+					invoke "mrsk:cli:healthcheck:perform", [], invoke_options
+				end
 
         say "Detect stale containers...", :magenta
         invoke "mrsk:cli:app:stale_containers", [], invoke_options

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -34,12 +34,12 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
         say "Ensure Traefik is running...", :magenta
         invoke "mrsk:cli:traefik:boot", [], invoke_options
 
-				if MRSK.config.healthcheck["skip"]
-					say "Skipping healthcheck...", :magenta
-				else
-					say "Ensure app can pass healthcheck...", :magenta
-					invoke "mrsk:cli:healthcheck:perform", [], invoke_options
-				end
+        if MRSK.config.healthcheck["skip"]
+          say "Skipping healthcheck...", :magenta
+        else
+          say "Ensure app can pass healthcheck...", :magenta
+          invoke "mrsk:cli:healthcheck:perform", [], invoke_options
+        end
 
         say "Detect stale containers...", :magenta
         invoke "mrsk:cli:app:stale_containers", [], invoke_options
@@ -71,12 +71,12 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
           invoke "mrsk:cli:build:deliver", [], invoke_options
         end
 
-				if MRSK.config.healthcheck["skip"]
-					say "Skipping healthcheck...", :magenta
-				else
-					say "Ensure app can pass healthcheck...", :magenta
-					invoke "mrsk:cli:healthcheck:perform", [], invoke_options
-				end
+        if MRSK.config.healthcheck["skip"]
+          say "Skipping healthcheck...", :magenta
+        else
+          say "Ensure app can pass healthcheck...", :magenta
+          invoke "mrsk:cli:healthcheck:perform", [], invoke_options
+        end
 
         say "Detect stale containers...", :magenta
         invoke "mrsk:cli:app:stale_containers", [], invoke_options

--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -158,7 +158,7 @@ class Mrsk::Configuration
   end
 
   def healthcheck
-    { "path" => "/up", "port" => 3000, "max_attempts" => 7 }.merge(raw_config.healthcheck || {})
+    { "path" => "/up", "port" => 3000, "max_attempts" => 7, "skip" => false }.merge(raw_config.healthcheck || {})
   end
 
   def readiness_delay

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -249,6 +249,6 @@ class ConfigurationTest < ActiveSupport::TestCase
   end
 
   test "to_h" do
-    assert_equal({ :roles=>["web"], :hosts=>["1.1.1.1", "1.1.1.2"], :primary_host=>"1.1.1.1", :version=>"missing", :repository=>"dhh/app", :absolute_image=>"dhh/app:missing", :service_with_version=>"app-missing", :env_args=>["-e", "REDIS_URL=\"redis://x/y\""], :ssh_options=>{:user=>"root", :auth_methods=>["publickey"]}, :volume_args=>["--volume", "/local/path:/container/path"], :logging=>["--log-opt", "max-size=\"10m\""], :healthcheck=>{"path"=>"/up", "port"=>3000, "max_attempts" => 7 }}, @config.to_h)
+    assert_equal({ :roles=>["web"], :hosts=>["1.1.1.1", "1.1.1.2"], :primary_host=>"1.1.1.1", :version=>"missing", :repository=>"dhh/app", :absolute_image=>"dhh/app:missing", :service_with_version=>"app-missing", :env_args=>["-e", "REDIS_URL=\"redis://x/y\""], :ssh_options=>{:user=>"root", :auth_methods=>["publickey"]}, :volume_args=>["--volume", "/local/path:/container/path"], :logging=>["--log-opt", "max-size=\"10m\""], :healthcheck=>{"path"=>"/up", "port"=>3000, "max_attempts" => 7, "skip" => false }}, @config.to_h)
   end
 end


### PR DESCRIPTION
Optional setting `skip` can be useful for deploying bots (Discord bots, Twitch bots, regular jobs) or anything that does not require an incoming HTTP connection. The default is false.

```yaml
healthcheck:
  skip: true
```