### PR TITLE
Integration test healthcheck wget

### DIFF
--- a/lib/mrsk/utils/healthcheck_poller.rb
+++ b/lib/mrsk/utils/healthcheck_poller.rb
@@ -1,5 +1,5 @@
 class Mrsk::Utils::HealthcheckPoller
-  TRAEFIK_HEALTHY_DELAY = 1
+  TRAEFIK_HEALTHY_DELAY = 2
 
   class HealthcheckError < StandardError; end
 

--- a/test/integration/deploy_test.rb
+++ b/test/integration/deploy_test.rb
@@ -55,6 +55,8 @@ class DeployTest < ActiveSupport::TestCase
       if code != "200"
         puts "Got response code #{code}, here are the traefik logs:"
         mrsk :traefik, :logs
+        puts "Add here are the load balancer logs"
+        docker_compose :logs, :load_balancer
       end
       assert_equal "200", code
     end

--- a/test/integration/deploy_test.rb
+++ b/test/integration/deploy_test.rb
@@ -61,7 +61,10 @@ class DeployTest < ActiveSupport::TestCase
     def wait_for_healthy(timeout: 20)
       timeout_at = Time.now + timeout
       while docker_compose("ps -a | tail -n +2 | grep -v '(healthy)' | wc -l", capture: true) != "0"
-        raise "Container not healthy after #{timeout} seconds" if timeout_at < Time.now
+        if timeout_at < Time.now
+          docker_compose("ps -a | tail -n +2 | grep -v '(healthy)'")
+          raise "Container not healthy after #{timeout} seconds" if timeout_at < Time.now
+        end
         sleep 0.1
       end
     end

--- a/test/integration/deploy_test.rb
+++ b/test/integration/deploy_test.rb
@@ -51,7 +51,12 @@ class DeployTest < ActiveSupport::TestCase
     end
 
     def assert_app_is_up
-      assert_equal "200", app_response.code
+      code = app_response.code
+      if code != "200"
+        puts "Got response code #{code}, here are the traefik logs:"
+        mrsk :traefik, :logs
+      end
+      assert_equal "200", code
     end
 
     def app_response

--- a/test/integration/deploy_test.rb
+++ b/test/integration/deploy_test.rb
@@ -55,8 +55,9 @@ class DeployTest < ActiveSupport::TestCase
       if code != "200"
         puts "Got response code #{code}, here are the traefik logs:"
         mrsk :traefik, :logs
-        puts "Add here are the load balancer logs"
+        puts "And here are the load balancer logs"
         docker_compose :logs, :load_balancer
+        puts "Tried to get the response code again and got #{app_response.code}"
       end
       assert_equal "200", code
     end

--- a/test/integration/docker/deployer/Dockerfile
+++ b/test/integration/docker/deployer/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:3.2
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y ca-certificates openssh-client curl gnupg docker.io
+RUN apt-get update --fix-missing && apt-get install -y ca-certificates openssh-client curl gnupg docker.io
 
 RUN install -m 0755 -d /etc/apt/keyrings
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
@@ -12,7 +12,7 @@ RUN echo \
   "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
   tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-RUN apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+RUN apt-get update --fix-missing && apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 COPY boot.sh .
 COPY app/ .

--- a/test/integration/docker/deployer/app/config/deploy.yml
+++ b/test/integration/docker/deployer/app/config/deploy.yml
@@ -11,3 +11,7 @@ builder:
   multiarch: false
 healthcheck:
   cmd: wget -qO- http://localhost > /dev/null
+traefik:
+  args:
+    accesslog: true
+    accesslog.format: json

--- a/test/integration/docker/deployer/app/config/deploy.yml
+++ b/test/integration/docker/deployer/app/config/deploy.yml
@@ -10,5 +10,4 @@ registry:
 builder:
   multiarch: false
 healthcheck:
-  path: /
-  port: 80
+  cmd: wget -qO- http://localhost > /dev/null

--- a/test/integration/docker/shared/Dockerfile
+++ b/test/integration/docker/shared/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.10
 
 WORKDIR /work
 
-RUN apt-get update && apt-get -y install openssh-client openssl
+RUN apt-get update --fix-missing && apt-get -y install openssh-client openssl
 
 RUN mkdir ssh && \
   ssh-keygen -t rsa -f ssh/id_rsa -N ""

--- a/test/integration/docker/vm/Dockerfile
+++ b/test/integration/docker/vm/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.10
 
 WORKDIR /work
 
-RUN apt-get update && apt-get -y install openssh-client openssh-server docker.io
+RUN apt-get update --fix-missing && apt-get -y install openssh-client openssh-server docker.io
 
 RUN mkdir /root/.ssh && ln -s /shared/ssh/id_rsa.pub /root/.ssh/authorized_keys
 RUN mkdir -p /etc/docker/certs.d/registry:4443 && ln -s /shared/certs/domain.crt /etc/docker/certs.d/registry:4443/ca.crt


### PR DESCRIPTION
The alpine nginx container doesn't contain curl, so let's override the
healthcheck command to use wget.