### PR TITLE
Check all hosts before rolling back

### DIFF
--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -246,7 +246,7 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
         end
       rescue SSHKit::Runner::ExecuteError => e
         if e.message =~ /Container not found/
-          say "Cannot rollback: #{e.message}"
+          say "Error looking for container version #{version}: #{e.message}"
           return false
         else
           raise

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -236,15 +236,24 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
   subcommand "lock", Mrsk::Cli::Lock
 
   private
-    def container_available?(version, host: MRSK.primary_host)
-      available = nil
-
-      on(host) do
-        first_role = MRSK.roles_on(host).first
-        available = capture_with_info(*MRSK.app(role: first_role).container_id_for_version(version)).present?
+    def container_available?(version)
+      begin
+        on(MRSK.hosts) do
+          MRSK.roles_on(host).each do |role|
+            container_id = capture_with_info(*MRSK.app(role: role).container_id_for_version(version))
+            raise "Container not found" unless container_id.present?
+          end
+        end
+      rescue SSHKit::Runner::ExecuteError => e
+        if e.message =~ /Container not found/
+          say "Cannot rollback: #{e.message}"
+          return false
+        else
+          raise
+        end
       end
 
-      available
+      true
     end
 
     def deploy_options


### PR DESCRIPTION
Hosts could end up out of sync with each other if prune commands are run manually or when new hosts are added.

Before rolling back confirm that the required container is available on all hosts and roles.