### PR TITLE
Add local dependencies check

### DIFF
--- a/lib/mrsk/cli/build.rb
+++ b/lib/mrsk/cli/build.rb
@@ -12,18 +12,18 @@ class Mrsk::Cli::Build < Mrsk::Cli::Base
   desc "push", "Build and push app image to registry"
   def push
     with_lock do
-      cli_build = self
+      cli = self
 
       run_locally do
         begin
-          if cli_build.dependencies
+          if cli.dependencies
             MRSK.with_verbosity(:debug) { execute *MRSK.builder.push }
           end
         rescue SSHKit::Command::Failed => e
           if e.message =~ /(no builder)|(no such file or directory)/
             error "Missing compatible builder, so creating a new one first"
 
-            if cli_build.create
+            if cli.create
               MRSK.with_verbosity(:debug) { execute *MRSK.builder.push }
             end
           else
@@ -94,6 +94,7 @@ class Mrsk::Cli::Build < Mrsk::Cli::Base
         raise BuildError, build_error
       end
     end
+
     true
   end
 end

--- a/lib/mrsk/cli/build.rb
+++ b/lib/mrsk/cli/build.rb
@@ -1,5 +1,4 @@
 class Mrsk::Cli::Build < Mrsk::Cli::Base
-
   class BuildError < StandardError; end
 
   desc "deliver", "Build app and push app image to registry then pull image on servers"

--- a/lib/mrsk/cli/build.rb
+++ b/lib/mrsk/cli/build.rb
@@ -16,7 +16,7 @@ class Mrsk::Cli::Build < Mrsk::Cli::Base
 
       run_locally do
         begin
-          if cli.dependencies
+          if cli.verify_dependencies
             MRSK.with_verbosity(:debug) { execute *MRSK.builder.push }
           end
         rescue SSHKit::Command::Failed => e
@@ -82,15 +82,17 @@ class Mrsk::Cli::Build < Mrsk::Cli::Base
     end
   end
 
-  desc "dependencies", "Check local dependencies"
-  def dependencies
+
+  desc "", "" # Really a private method, but needed to be invoked from #push
+  def verify_dependencies
     run_locally do
       begin
-        execute *MRSK.builder.dependencies
+        execute *MRSK.builder.ensure_dependencies_installed
       rescue SSHKit::Command::Failed => e
         build_error = e.message =~ /command not found/ ?
           "Docker is not installed locally" :
           "Docker buildx plugin is not installed locally"
+
         raise BuildError, build_error
       end
     end

--- a/lib/mrsk/cli/build.rb
+++ b/lib/mrsk/cli/build.rb
@@ -16,7 +16,7 @@ class Mrsk::Cli::Build < Mrsk::Cli::Base
 
       run_locally do
         begin
-          if cli.verify_dependencies
+          if cli.verify_local_dependencies
             MRSK.with_verbosity(:debug) { execute *MRSK.builder.push }
           end
         rescue SSHKit::Command::Failed => e
@@ -84,7 +84,7 @@ class Mrsk::Cli::Build < Mrsk::Cli::Base
 
 
   desc "", "" # Really a private method, but needed to be invoked from #push
-  def verify_dependencies
+  def verify_local_dependencies
     run_locally do
       begin
         execute *MRSK.builder.ensure_local_dependencies_installed

--- a/lib/mrsk/cli/build.rb
+++ b/lib/mrsk/cli/build.rb
@@ -87,7 +87,7 @@ class Mrsk::Cli::Build < Mrsk::Cli::Base
   def verify_dependencies
     run_locally do
       begin
-        execute *MRSK.builder.ensure_dependencies_installed
+        execute *MRSK.builder.ensure_local_dependencies_installed
       rescue SSHKit::Command::Failed => e
         build_error = e.message =~ /command not found/ ?
           "Docker is not installed locally" :

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -17,7 +17,7 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
       invoke_options = deploy_options
 
       runtime = print_runtime do
-        say "Ensure curl and Docker are installed...", :magenta
+        say "Ensure curl and Docker are installed on servers...", :magenta
         invoke "mrsk:cli:server:bootstrap", [], invoke_options
 
         say "Log into image registry...", :magenta

--- a/lib/mrsk/commands/builder.rb
+++ b/lib/mrsk/commands/builder.rb
@@ -33,4 +33,28 @@ class Mrsk::Commands::Builder < Mrsk::Commands::Base
   def multiarch_remote
     @multiarch_remote ||= Mrsk::Commands::Builder::Multiarch::Remote.new(config)
   end
+
+  def native_and_local?
+    name == 'native'
+  end
+
+  def dependencies
+    if native_and_local?
+      docker_version
+    else
+    combine \
+      docker_version,
+      docker_buildx_version
+    end
+  end
+
+  private
+
+    def docker_version
+      docker "--version"
+    end
+
+    def docker_buildx_version
+      docker :buildx, "version"
+    end
 end

--- a/lib/mrsk/commands/builder.rb
+++ b/lib/mrsk/commands/builder.rb
@@ -2,7 +2,7 @@ class Mrsk::Commands::Builder < Mrsk::Commands::Base
   delegate :create, :remove, :push, :clean, :pull, :info, to: :target
 
   def name
-    target.class.to_s.remove("Mrsk::Commands::Builder::").underscore
+    target.class.to_s.remove("Mrsk::Commands::Builder::").underscore.inquiry
   end
 
   def target
@@ -34,26 +34,23 @@ class Mrsk::Commands::Builder < Mrsk::Commands::Base
     @multiarch_remote ||= Mrsk::Commands::Builder::Multiarch::Remote.new(config)
   end
 
-  def native_and_local?
-    name == 'native'
-  end
 
-  def dependencies
-    if native_and_local?
-      docker_version
+  def ensure_dependencies_installed
+    if name.native?
+      ensure_docker_installed
     else
       combine \
-        docker_version,
-        docker_buildx_version
+        ensure_docker_installed,
+        ensure_buildx_installed
     end
   end
 
   private
-    def docker_version
+    def ensure_docker_installed
       docker "--version"
     end
 
-    def docker_buildx_version
+    def ensure_buildx_installed
       docker :buildx, "version"
     end
 end

--- a/lib/mrsk/commands/builder.rb
+++ b/lib/mrsk/commands/builder.rb
@@ -35,22 +35,22 @@ class Mrsk::Commands::Builder < Mrsk::Commands::Base
   end
 
 
-  def ensure_dependencies_installed
+  def ensure_local_dependencies_installed
     if name.native?
-      ensure_docker_installed
+      ensure_local_docker_installed
     else
       combine \
-        ensure_docker_installed,
-        ensure_buildx_installed
+        ensure_local_docker_installed,
+        ensure_local_buildx_installed
     end
   end
 
   private
-    def ensure_docker_installed
+    def ensure_local_docker_installed
       docker "--version"
     end
 
-    def ensure_buildx_installed
+    def ensure_local_buildx_installed
       docker :buildx, "version"
     end
 end

--- a/lib/mrsk/commands/builder.rb
+++ b/lib/mrsk/commands/builder.rb
@@ -42,14 +42,13 @@ class Mrsk::Commands::Builder < Mrsk::Commands::Base
     if native_and_local?
       docker_version
     else
-    combine \
-      docker_version,
-      docker_buildx_version
+      combine \
+        docker_version,
+        docker_buildx_version
     end
   end
 
   private
-
     def docker_version
       docker "--version"
     end

--- a/lib/mrsk/commands/builder/base.rb
+++ b/lib/mrsk/commands/builder/base.rb
@@ -1,8 +1,8 @@
 
 class Mrsk::Commands::Builder::Base < Mrsk::Commands::Base
-  delegate :argumentize, to: Mrsk::Utils
-
   class BuilderError < StandardError; end
+
+  delegate :argumentize, to: Mrsk::Utils
 
   def clean
     docker :image, :rm, "--force", config.absolute_image

--- a/lib/mrsk/commands/builder/base.rb
+++ b/lib/mrsk/commands/builder/base.rb
@@ -1,5 +1,8 @@
+
 class Mrsk::Commands::Builder::Base < Mrsk::Commands::Base
   delegate :argumentize, to: Mrsk::Utils
+
+  class BuilderError < StandardError; end
 
   def clean
     docker :image, :rm, "--force", config.absolute_image
@@ -16,6 +19,7 @@ class Mrsk::Commands::Builder::Base < Mrsk::Commands::Base
   def build_context
     context
   end
+
 
   private
     def build_tags
@@ -35,7 +39,11 @@ class Mrsk::Commands::Builder::Base < Mrsk::Commands::Base
     end
 
     def build_dockerfile
-      argumentize "--file", dockerfile
+      if Pathname.new(File.expand_path(dockerfile)).exist?
+        argumentize "--file", dockerfile
+      else
+        raise BuilderError, "Missing Dockerfile"
+      end
     end
 
     def args

--- a/lib/mrsk/commands/builder/base.rb
+++ b/lib/mrsk/commands/builder/base.rb
@@ -42,7 +42,7 @@ class Mrsk::Commands::Builder::Base < Mrsk::Commands::Base
       if Pathname.new(File.expand_path(dockerfile)).exist?
         argumentize "--file", dockerfile
       else
-        raise BuilderError, "Missing Dockerfile"
+        raise BuilderError, "Missing #{dockerfile}"
       end
     end
 

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -9,7 +9,7 @@ class CliBuildTest < CliTestCase
   end
 
   test "push" do
-    Mrsk::Cli::Build.any_instance.stubs(:verify_dependencies).returns(true)
+    Mrsk::Cli::Build.any_instance.stubs(:verify_local_dependencies).returns(true)
     run_command("push").tap do |output|
       assert_match /docker buildx build --push --platform linux\/amd64,linux\/arm64 --builder mrsk-app-multiarch -t dhh\/app:999 -t dhh\/app:latest --label service="app" --file Dockerfile \. as .*@localhost/, output
     end
@@ -17,7 +17,7 @@ class CliBuildTest < CliTestCase
 
   test "push without builder" do
     stub_locking
-    Mrsk::Cli::Build.any_instance.stubs(:verify_dependencies).returns(true)
+    Mrsk::Cli::Build.any_instance.stubs(:verify_local_dependencies).returns(true)
     SSHKit::Backend::Abstract.any_instance.stubs(:execute)
       .with { |arg| arg == :docker }
       .raises(SSHKit::Command::Failed.new("no builder"))
@@ -73,7 +73,7 @@ class CliBuildTest < CliTestCase
   test "verify local dependencies" do
     Mrsk::Commands::Builder.any_instance.stubs(:name).returns("remote".inquiry)
 
-    run_command("verify_dependencies").tap do |output|
+    run_command("verify_local_dependencies").tap do |output|
       assert_match /docker --version && docker buildx version/, output
     end
   end
@@ -84,7 +84,7 @@ class CliBuildTest < CliTestCase
       .raises(SSHKit::Command::Failed.new("no buildx"))
 
     Mrsk::Commands::Builder.any_instance.stubs(:native_and_local?).returns(false)
-    assert_raises(Mrsk::Cli::Build::BuildError) { run_command("verify_dependencies") }
+    assert_raises(Mrsk::Cli::Build::BuildError) { run_command("verify_local_dependencies") }
   end
 
   private

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -70,7 +70,7 @@ class CliBuildTest < CliTestCase
     end
   end
 
-  test "verify dependencies" do
+  test "verify local dependencies" do
     Mrsk::Commands::Builder.any_instance.stubs(:name).returns("remote".inquiry)
 
     run_command("verify_dependencies").tap do |output|
@@ -78,7 +78,7 @@ class CliBuildTest < CliTestCase
     end
   end
 
-  test "dependencies with no buildx plugin" do
+  test "verify local dependencies with no buildx plugin" do
     SSHKit::Backend::Abstract.any_instance.stubs(:execute)
       .with(:docker, "--version", "&&", :docker, :buildx, "version")
       .raises(SSHKit::Command::Failed.new("no buildx"))

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -9,7 +9,7 @@ class CliBuildTest < CliTestCase
   end
 
   test "push" do
-    Mrsk::Cli::Build.any_instance.stubs(:dependencies).returns(true)
+    Mrsk::Cli::Build.any_instance.stubs(:verify_dependencies).returns(true)
     run_command("push").tap do |output|
       assert_match /docker buildx build --push --platform linux\/amd64,linux\/arm64 --builder mrsk-app-multiarch -t dhh\/app:999 -t dhh\/app:latest --label service="app" --file Dockerfile \. as .*@localhost/, output
     end
@@ -17,7 +17,7 @@ class CliBuildTest < CliTestCase
 
   test "push without builder" do
     stub_locking
-    Mrsk::Cli::Build.any_instance.stubs(:dependencies).returns(true)
+    Mrsk::Cli::Build.any_instance.stubs(:verify_dependencies).returns(true)
     SSHKit::Backend::Abstract.any_instance.stubs(:execute)
       .with { |arg| arg == :docker }
       .raises(SSHKit::Command::Failed.new("no builder"))
@@ -70,9 +70,10 @@ class CliBuildTest < CliTestCase
     end
   end
 
-  test "dependencies" do
-    Mrsk::Commands::Builder.any_instance.stubs(:native_and_local?).returns(false)
-    run_command("dependencies").tap do |output|
+  test "verify dependencies" do
+    Mrsk::Commands::Builder.any_instance.stubs(:name).returns("remote".inquiry)
+
+    run_command("verify_dependencies").tap do |output|
       assert_match /docker --version && docker buildx version/, output
     end
   end
@@ -83,7 +84,7 @@ class CliBuildTest < CliTestCase
       .raises(SSHKit::Command::Failed.new("no buildx"))
 
     Mrsk::Commands::Builder.any_instance.stubs(:native_and_local?).returns(false)
-    assert_raises(Mrsk::Cli::Build::BuildError) { run_command("dependencies") }
+    assert_raises(Mrsk::Cli::Build::BuildError) { run_command("verify_dependencies") }
   end
 
   private

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -52,10 +52,19 @@ class CommandsBuilderTest < ActiveSupport::TestCase
   end
 
   test "build dockerfile" do
+    Pathname.any_instance.expects(:exist?).returns(true).once
     builder = new_builder_command(builder: { "dockerfile" => "Dockerfile.xyz" })
     assert_equal \
       "-t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile.xyz",
       builder.target.build_options.join(" ")
+  end
+
+  test "missing dockerfile" do
+    Pathname.any_instance.expects(:exist?).returns(false).once
+    builder = new_builder_command(builder: { "dockerfile" => "Dockerfile.xyz" })
+    assert_raises(Mrsk::Commands::Builder::Base::BuilderError) do
+      builder.target.build_options.join(" ")
+    end
   end
 
   test "build context" do

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -48,7 +48,7 @@ class ConfigurationTest < ActiveSupport::TestCase
   end
 
   test "role" do
-    assert_equal "web", @config.role(:web).name
+    assert @config.role(:web).name.web?
     assert_equal "workers", @config_with_roles.role(:workers).name
     assert_nil @config.role(:missing)
   end


### PR DESCRIPTION
Add checks for:

* Docker installed locally
* Docker buildx plugin installed locally
* Dockerfile exists

If checks fail, it will halt deployment and provide more specific error messages.

Also adds a cli subcommand:
`mrsk build dependencies`

Fixes: #109 and #237