### PR TITLE
Fix aggressive prune breaking rollback

### DIFF
--- a/lib/mrsk/commands/prune.rb
+++ b/lib/mrsk/commands/prune.rb
@@ -3,7 +3,7 @@ require "active_support/core_ext/numeric/time"
 
 class Mrsk::Commands::Prune < Mrsk::Commands::Base
   def images
-    docker :image, :prune, "--all", "--force", "--filter", "label=service=#{config.service}", "--filter", "dangling=true"
+    docker :image, :prune, "--force", "--filter", "label=service=#{config.service}", "--filter", "dangling=true"
   end
 
   def containers(keep_last: 5)

--- a/test/cli/prune_test.rb
+++ b/test/cli/prune_test.rb
@@ -10,7 +10,7 @@ class CliPruneTest < CliTestCase
 
   test "images" do
     run_command("images").tap do |output|
-      assert_match /docker image prune --all --force --filter label=service=app --filter dangling=true on 1.1.1.\d/, output
+      assert_match /docker image prune --force --filter label=service=app --filter dangling=true on 1.1.1.\d/, output
     end
   end
 

--- a/test/commands/prune_test.rb
+++ b/test/commands/prune_test.rb
@@ -10,7 +10,7 @@ class CommandsPruneTest < ActiveSupport::TestCase
 
   test "images" do
     assert_equal \
-      "docker image prune --all --force --filter label=service=app --filter dangling=true",
+      "docker image prune --force --filter label=service=app --filter dangling=true",
       new_command.images.join(" ")
   end
 

--- a/test/integration/docker/deployer/Dockerfile
+++ b/test/integration/docker/deployer/Dockerfile
@@ -14,7 +14,7 @@ RUN echo \
 
 RUN apt-get update --fix-missing && apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-COPY boot.sh .
+COPY *.sh .
 COPY app/ .
 
 RUN ln -s /shared/ssh /root/.ssh
@@ -23,6 +23,7 @@ RUN mkdir -p /etc/docker/certs.d/registry:4443 && ln -s /shared/certs/domain.crt
 RUN git config --global user.email "deployer@example.com"
 RUN git config --global user.name "Deployer"
 RUN git init && git add . && git commit -am "Initial version"
+RUN git rev-parse HEAD > version
 
 HEALTHCHECK --interval=1s CMD pgrep sleep
 

--- a/test/integration/docker/deployer/app/Dockerfile
+++ b/test/integration/docker/deployer/app/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:1-alpine-slim
 
 COPY default.conf /etc/nginx/conf.d/default.conf
+COPY version /usr/share/nginx/html/version

--- a/test/integration/docker/deployer/update_app_rev.sh
+++ b/test/integration/docker/deployer/update_app_rev.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+git commit -am 'Update rev' --amend
+git rev-parse HEAD > version


### PR DESCRIPTION
In the image prune command --all overrides --dangling=true. This removes the image git sha image tag for the latest image which prevented us from rolling back to it.

I've updated the integration test to now test deploy, redeploy and rollback.