### PR TITLE
Call app:boot to rollback

### DIFF
--- a/lib/mrsk/cli/app.rb
+++ b/lib/mrsk/cli/app.rb
@@ -2,37 +2,39 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
   desc "boot", "Boot app on servers (or reboot app if already running)"
   def boot
     with_lock do
-      say "Get most recent version available as an image...", :magenta unless options[:version]
-      using_version(version_or_latest) do |version|
-        say "Start container with version #{version} using a #{MRSK.config.readiness_delay}s readiness delay (or reboot if already running)...", :magenta
+      hold_lock_on_error do
+        say "Get most recent version available as an image...", :magenta unless options[:version]
+        using_version(version_or_latest) do |version|
+          say "Start container with version #{version} using a #{MRSK.config.readiness_delay}s readiness delay (or reboot if already running)...", :magenta
 
-        on(MRSK.hosts) do
-          execute *MRSK.auditor.record("Tagging #{MRSK.config.absolute_image} as the latest image"), verbosity: :debug
-          execute *MRSK.app.tag_current_as_latest
-        end
+          on(MRSK.hosts) do
+            execute *MRSK.auditor.record("Tagging #{MRSK.config.absolute_image} as the latest image"), verbosity: :debug
+            execute *MRSK.app.tag_current_as_latest
+          end
 
-        on(MRSK.hosts, **MRSK.boot_strategy) do |host|
-          roles = MRSK.roles_on(host)
+          on(MRSK.hosts, **MRSK.boot_strategy) do |host|
+            roles = MRSK.roles_on(host)
 
-          roles.each do |role|
-            app = MRSK.app(role: role)
-            auditor = MRSK.auditor(role: role)
+            roles.each do |role|
+              app = MRSK.app(role: role)
+              auditor = MRSK.auditor(role: role)
 
-            execute *auditor.record("Booted app version #{version}"), verbosity: :debug
+              if capture_with_info(*app.container_id_for_version(version, only_running: true), raise_on_non_zero_exit: false).present?
+                tmp_version = "#{version}_replaced_#{SecureRandom.hex(8)}"
+                info "Renaming container #{version} to #{tmp_version} as already deployed on #{host}"
+                execute *auditor.record("Renaming container #{version} to #{tmp_version}"), verbosity: :debug
+                execute *app.rename_container(version: version, new_version: tmp_version)
+              end
 
-            if capture_with_info(*app.container_id_for_version(version), raise_on_non_zero_exit: false).present?
-              tmp_version = "#{version}_replaced_#{SecureRandom.hex(8)}"
-              info "Renaming container #{version} to #{tmp_version} as already deployed on #{host}"
-              execute *auditor.record("Renaming container #{version} to #{tmp_version}"), verbosity: :debug
-              execute *app.rename_container(version: version, new_version: tmp_version)
+              execute *auditor.record("Booted app version #{version}"), verbosity: :debug
+
+              old_version = capture_with_info(*app.current_running_version, raise_on_non_zero_exit: false).strip
+              execute *app.start_or_run
+
+              Mrsk::Utils::HealthcheckPoller.wait_for_healthy(pause_after_ready: true) { capture_with_info(*app.status(version: version)) }
+
+              execute *app.stop(version: old_version), raise_on_non_zero_exit: false if old_version.present?
             end
-
-            old_version = capture_with_info(*app.current_running_version, raise_on_non_zero_exit: false).strip
-            execute *app.run
-
-            Mrsk::Utils::HealthcheckPoller.wait_for_healthy(pause_after_ready: true) { capture_with_info(*app.status(version: version)) }
-
-            execute *app.stop(version: old_version), raise_on_non_zero_exit: false if old_version.present?
           end
         end
       end

--- a/lib/mrsk/commands/app.rb
+++ b/lib/mrsk/commands/app.rb
@@ -6,6 +6,10 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
     @role = role
   end
 
+  def start_or_run
+    combine start, run, by: "||"
+  end
+
   def run
     role = config.role(self.role)
 
@@ -91,8 +95,8 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
     docker :ps, "--quiet", *filter_args(status: :running), "--latest"
   end
 
-  def container_id_for_version(version)
-    container_id_for(container_name: container_name(version))
+  def container_id_for_version(version, only_running: false)
+    container_id_for(container_name: container_name(version), only_running: only_running)
   end
 
   def current_running_version

--- a/lib/mrsk/commands/base.rb
+++ b/lib/mrsk/commands/base.rb
@@ -18,8 +18,8 @@ module Mrsk::Commands
       end
     end
 
-    def container_id_for(container_name:)
-      docker :container, :ls, "--all", "--filter", "name=^#{container_name}$", "--quiet"
+    def container_id_for(container_name:, only_running: false)
+      docker :container, :ls, *("--all" unless only_running), "--filter", "name=^#{container_name}$", "--quiet"
     end
 
     private


### PR DESCRIPTION
The code in Mrsk::Cli::Main#rollback was very similar to Mrsk::Cli::App#boot.

Modify Mrsk::Cli::App#boot so it can handle rollbacks by:
1. Only renaming running containers
2. Trying first to start then run the new container