### PR TITLE
Fix readme bug on traefik volumes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ traefik:
   options:
     publish:
       - 8080:8080
-    volumes:
+    volume:
       - /tmp/example.json:/tmp/example.json
     memory: 512m
 ```


### PR DESCRIPTION
To mount extra volumes to Traefik instance, the right option should be `volume` instead of `volumes`

```diff
traefik:
  options:
    publish:
      - 8080:8080
-   volumes:
+   volume:
      - /tmp/example.json:/tmp/example.json
    memory: 512m
```