### PR TITLE
add healthcheck interval option

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,6 +703,7 @@ healthcheck:
   path: /healthz
   port: 4000
   max_attempts: 7
+  interval: 20s
 ```
 
 This will ensure your application is configured with a traefik label for the healthcheck against `/healthz` and that the pre-deploy healthcheck that MRSK performs is done against the same path on port 4000.

--- a/lib/mrsk/configuration/role.rb
+++ b/lib/mrsk/configuration/role.rb
@@ -37,7 +37,7 @@ class Mrsk::Configuration::Role
 
   def health_check_args
     if health_check_cmd.present?
-      optionize({ "health-cmd" => health_check_cmd, "health-interval" => "1s" })
+      optionize({ "health-cmd" => health_check_cmd, "health-interval" => health_check_interval })
     else
       []
     end
@@ -48,6 +48,13 @@ class Mrsk::Configuration::Role
     options = config.healthcheck.merge(options) if running_traefik?
 
     options["cmd"] || http_health_check(port: options["port"], path: options["path"])
+  end
+
+  def health_check_interval
+    options = specializations["healthcheck"] || {}
+    options = config.healthcheck.merge(options) if running_traefik?
+
+    options["interval"] || "1s"
   end
 
   def cmd


### PR DESCRIPTION
The current health check happens every `1s`, this PR introduces the `interval` option to customize docker `--health-interval`

```sh
healthcheck:
  path: /up
  port: 3000
  interval: 20s
```