### PR TITLE
Highlight uncommitted changes in version

### DIFF
--- a/lib/mrsk/cli/app.rb
+++ b/lib/mrsk/cli/app.rb
@@ -21,7 +21,7 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
             execute *auditor.record("Booted app version #{version}"), verbosity: :debug
 
             if capture_with_info(*app.container_id_for_version(version), raise_on_non_zero_exit: false).present?
-              tmp_version = "#{version}_#{SecureRandom.hex(8)}"
+              tmp_version = "#{version}_replaced_#{SecureRandom.hex(8)}"
               info "Renaming container #{version} to #{tmp_version} as already deployed on #{host}"
               execute *auditor.record("Renaming container #{version} to #{tmp_version}"), verbosity: :debug
               execute *app.rename_container(version: version, new_version: tmp_version)

--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -50,7 +50,7 @@ class Mrsk::Configuration
   end
 
   def version
-    @declared_version.presence || ENV["VERSION"] || current_commit_hash
+    @declared_version.presence || ENV["VERSION"] || git_version
   end
 
   def abbreviated_version
@@ -233,10 +233,12 @@ class Mrsk::Configuration
       raw_config.servers.is_a?(Array) ? [ "web" ] : raw_config.servers.keys.sort
     end
 
-    def current_commit_hash
-      @current_commit_hash ||=
+    def git_version
+      @git_version ||=
         if system("git rev-parse")
-          `git rev-parse HEAD`.strip
+          uncommitted_suffix = `git status --porcelain`.strip.present? ? "_uncommitted_#{SecureRandom.hex(8)}" : ""
+
+          "#{`git rev-parse HEAD`.strip}#{uncommitted_suffix}"
         else
           raise "Can't use commit hash as version, no git repository found in #{Dir.pwd}"
         end

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -32,7 +32,7 @@ class CliAppTest < CliTestCase
 
     run_command("boot").tap do |output|
       assert_match /Renaming container .* to .* as already deployed on 1.1.1.1/, output # Rename
-      assert_match /docker rename .* .*/, output
+      assert_match /docker rename app-web-latest app-web-latest_replaced_[0-9a-f]{16}/, output
       assert_match "docker run --detach --restart unless-stopped", output
       assert_match "docker container ls --all --filter name=^app-web-123$ --quiet | xargs docker stop", output
     end

--- a/test/integration/deploy_test.rb
+++ b/test/integration/deploy_test.rb
@@ -110,7 +110,7 @@ class DeployTest < ActiveSupport::TestCase
     end
 
     def latest_app_version
-      deployer_exec("cat version", capture: true)
+      deployer_exec("git rev-parse HEAD", capture: true)
     end
 
     def assert_app_version(version)

--- a/test/integration/docker/deployer/Dockerfile
+++ b/test/integration/docker/deployer/Dockerfile
@@ -23,7 +23,6 @@ RUN mkdir -p /etc/docker/certs.d/registry:4443 && ln -s /shared/certs/domain.crt
 RUN git config --global user.email "deployer@example.com"
 RUN git config --global user.name "Deployer"
 RUN git init && git add . && git commit -am "Initial version"
-RUN git rev-parse HEAD > version
 
 HEALTHCHECK --interval=1s CMD pgrep sleep
 

--- a/test/integration/docker/deployer/app/Dockerfile
+++ b/test/integration/docker/deployer/app/Dockerfile
@@ -1,4 +1,7 @@
 FROM nginx:1-alpine-slim
 
 COPY default.conf /etc/nginx/conf.d/default.conf
-COPY version /usr/share/nginx/html/version
+
+ARG COMMIT_SHA
+RUN echo $COMMIT_SHA > /usr/share/nginx/html/version
+

--- a/test/integration/docker/deployer/app/config/deploy.yml
+++ b/test/integration/docker/deployer/app/config/deploy.yml
@@ -9,6 +9,8 @@ registry:
   password: root
 builder:
   multiarch: false
+  args:
+    COMMIT_SHA: <%= `git rev-parse HEAD` %>
 healthcheck:
   cmd: wget -qO- http://localhost > /dev/null
 traefik:

--- a/test/integration/docker/deployer/update_app_rev.sh
+++ b/test/integration/docker/deployer/update_app_rev.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 git commit -am 'Update rev' --amend
-git rev-parse HEAD > version


### PR DESCRIPTION
If there are uncommitted changes in the app repository when building, then append `_uncommitted_<random>` to the version to distinguish the image from one built from a clean checkout.

Also change the version used when renaming a container on redeploy to distinguish and explain the version suffixes.