### PR TITLE
Report the host an error occurred on

### DIFF
--- a/bin/mrsk
+++ b/bin/mrsk
@@ -8,7 +8,7 @@ require "mrsk"
 begin
   Mrsk::Cli::Main.start(ARGV)
 rescue SSHKit::Runner::ExecuteError => e
-  puts "  \e[31mERROR (#{e.cause.class}): #{e.cause.message}\e[0m"
+  puts "  \e[31mERROR (#{e.cause.class}): #{e.message}\e[0m"
   puts e.cause.backtrace if ENV["VERBOSE"]
   exit 1
 rescue => e


### PR DESCRIPTION
The cause message doesn't include the host the error occurred on.

Before:

```
$ mrsk deploy
Acquiring the deploy lock...
  Finished all in 0.1 seconds
  ERROR (SocketError): getaddrinfo: nodename nor servname provided, or not known
```

After:

```
$ mrsk deploy -d staging
Acquiring the deploy lock...
  Finished all in 0.1 seconds
  ERROR (SocketError): Exception while executing on host server-123: getaddrinfo: nodename nor servname provided, or not known
```