### PR TITLE
Update the README with info on AWS ECR

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,19 @@ registry:
 
 A reference to secret `DOCKER_REGISTRY_TOKEN` will look for `ENV["DOCKER_REGISTRY_TOKEN"]` on the machine running MRSK.
 
+#### Using AWS ECR as the container registry
+
+AWS ECR's access token is only valid for 12hrs. In order to not have to manually regenerate the token every time, you can use ERB in the `deploy.yml` file to shell out to the `aws` cli command, and obtain the token:
+
+```yaml
+registry:
+  server: <your aws account id>.dkr.ecr.<your aws region id>.amazonaws.com
+  username: AWS
+  password: <%= %x(aws ecr get-login-password) %>
+```
+
+You will need to have the `aws` CLI installed locally for this to work.
+
 ### Using a different SSH user than root
 
 The default SSH user is root, but you can change it using `ssh/user`:


### PR DESCRIPTION
Greetings 

AWS ECR required a fresh access token every 12hrs, which is a pain. Fortunately we can automate that by using ERB in the `deploy.yml` file to shell out and get the token. 

This PR updates the README with an example of how to do that. 