### PR TITLE
Add a pre-deploy hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -882,17 +882,22 @@ firing a JSON webhook. These variables include:
 - `MRSK_PERFORMER` - the local user performing the command (from `whoami`)
 - `MRSK_SERVICE_VERSION` - an abbreviated service and version for use in messages, e.g. app@150b24f
 - `MRSK_VERSION` - an full version being deployed
-- `MRSK_DESTINATION` - optional: destination, e.g. "staging"
 - `MRSK_HOSTS` - a comma separated list of the hosts targeted by the command
+- `MRSK_COMMAND` - The command we are running
+- `MRSK_SUBCOMMAND` - optional: The subcommand we are running
+- `MRSK_DESTINATION` - optional: destination, e.g. "staging"
 - `MRSK_ROLE` - optional: role targeted, e.g. "web"
 
-There are three hooks:
+There are four hooks:
 
 1. pre-connect
 Called before taking the deploy lock. For checks that need to run before connecting to remote hosts - e.g. DNS warming.
 
 2. pre-build
 Used for pre-build checks - e.g. there are no uncommitted changes or that CI has passed.
+
+3. pre-deploy
+For final checks before deploying, e.g. checking CI completed
 
 3. post-deploy - run after a deploy, redeploy or rollback
 

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -28,6 +28,8 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
           invoke "mrsk:cli:build:deliver", [], invoke_options
         end
 
+        run_hook "pre-deploy"
+
         say "Ensure Traefik is running...", :magenta
         invoke "mrsk:cli:traefik:boot", [], invoke_options
 
@@ -62,6 +64,8 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
           invoke "mrsk:cli:build:deliver", [], invoke_options
         end
 
+        run_hook "pre-deploy"
+
         say "Ensure app can pass healthcheck...", :magenta
         invoke "mrsk:cli:healthcheck:perform", [], invoke_options
 
@@ -86,6 +90,8 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
         old_version = nil
 
         if container_available?(version)
+          run_hook "pre-deploy"
+
           invoke "mrsk:cli:app:boot", [], invoke_options.merge(version: version)
           rolled_back = true
         else

--- a/lib/mrsk/cli/templates/sample_hooks/pre-deploy.sample
+++ b/lib/mrsk/cli/templates/sample_hooks/pre-deploy.sample
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+# A sample pre-deploy hook
+#
+# Checks the Github status of the build, waiting for a pending build to complete for up to 720 seconds.
+#
+# Fails unless the combined status is "success"
+#
+# These environment variables are available:
+# MRSK_RECORDED_AT
+# MRSK_PERFORMER
+# MRSK_VERSION
+# MRSK_HOSTS
+# MRSK_COMMAND
+# MRSK_SUBCOMMAND
+# MRSK_ROLE (if set)
+# MRSK_DESTINATION (if set)
+
+#!/usr/bin/env ruby
+
+# Only check the build status for production deployments
+if ENV["MRSK_COMMAND"] == "rollback" || ENV["MRSK_DESTINATION"] != "production"
+  exit 0
+end
+
+require "bundler/inline"
+
+# true = install gems so this is fast on repeat invocations
+gemfile(true, quiet: true) do
+  source "https://rubygems.org"
+
+  gem "octokit"
+  gem "faraday-retry"
+end
+
+MAX_ATTEMPTS = 72
+ATTEMPTS_GAP = 10
+
+def exit_with_error(message)
+  $stderr.puts message
+  exit 1
+end
+
+def first_status_url(combined_status, state)
+  first_status = combined_status[:statuses].find { |status| status[:state] == state }
+  first_status && first_status[:target_url]
+end
+
+remote_url = `git config --get remote.origin.url`.strip.delete_prefix("https://github.com/")
+git_sha = `git rev-parse HEAD`.strip
+
+repository = Octokit::Repository.from_url(remote_url)
+github_client = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
+attempts = 0
+
+begin
+  loop do
+    combined_status = github_client.combined_status(remote_url, git_sha)
+    state = combined_status[:state]
+    first_status_url = first_status_url(combined_status, state)
+
+    case state
+    when "success"
+      puts "Build passed, see #{first_status_url}"
+      exit 0
+    when "failure"
+      exit_with_error "Build failed, see #{first_status_url}"
+    when "pending"
+      attempts += 1
+    end
+
+    puts "Waiting #{ATTEMPTS_GAP} more seconds for build to complete#{", see #{first_status_url}" if first_status_url}..."
+
+    if attempts == MAX_ATTEMPTS
+      exit_with_error "Build status is still pending, gave up after #{MAX_ATTEMPTS * ATTEMPTS_GAP} seconds"
+    end
+
+    sleep(ATTEMPTS_GAP)
+  end
+rescue Octokit::NotFound
+  exit_with_error "Build status could not be found"
+end

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -9,7 +9,11 @@ class CliBuildTest < CliTestCase
   end
 
   test "push" do
+    Mrsk::Commands::Hook.any_instance.stubs(:hook_exists?).returns(true)
+    hook_variables = { version: 999, service_version: "app@999", hosts: "1.1.1.1,1.1.1.2,1.1.1.3,1.1.1.4", command: "build", subcommand: "push" }
+
     run_command("push").tap do |output|
+      assert_hook_ran "pre-build", output, **hook_variables
       assert_match /docker --version && docker buildx version/, output
       assert_match /docker buildx build --push --platform linux\/amd64,linux\/arm64 --builder mrsk-app-multiarch -t dhh\/app:999 -t dhh\/app:latest --label service="app" --file Dockerfile \. as .*@localhost/, output
     end

--- a/test/integration/docker/deployer/app/.mrsk/hooks/pre-deploy
+++ b/test/integration/docker/deployer/app/.mrsk/hooks/pre-deploy
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Deployed!"
+mkdir -p /tmp/${TEST_ID} && touch /tmp/${TEST_ID}/pre-deploy

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -8,16 +8,16 @@ class MainTest < IntegrationTest
 
     mrsk :deploy
     assert_app_is_up version: first_version
-    assert_hooks_ran "pre-connect", "pre-build", "post-deploy"
+    assert_hooks_ran "pre-connect", "pre-build", "pre-deploy", "post-deploy"
 
     second_version = update_app_rev
 
     mrsk :redeploy
     assert_app_is_up version: second_version
-    assert_hooks_ran "pre-connect", "pre-build", "post-deploy"
+    assert_hooks_ran "pre-connect", "pre-build", "pre-deploy", "post-deploy"
 
     mrsk :rollback, first_version
-    assert_hooks_ran "pre-connect", "post-deploy"
+    assert_hooks_ran "pre-connect", "pre-deploy", "post-deploy"
     assert_app_is_up version: first_version
 
     details = mrsk :details, capture: true


### PR DESCRIPTION
Useful for checking the status of CI before deploying. Doing this at this point in the deployment maximises the parallelisation of building and running CI.