### PR TITLE
Add support for proxy_command to run_over_ssh

### DIFF
--- a/lib/mrsk/commands/base.rb
+++ b/lib/mrsk/commands/base.rb
@@ -13,7 +13,11 @@ module Mrsk::Commands
 
     def run_over_ssh(*command, host:)
       "ssh".tap do |cmd|
-        cmd << " -J #{config.ssh_proxy.jump_proxies}" if config.ssh_proxy
+        if config.ssh_proxy && config.ssh_proxy.is_a?(Net::SSH::Proxy::Jump)
+          cmd << " -J #{config.ssh_proxy.jump_proxies}"
+        elsif config.ssh_proxy && config.ssh_proxy.is_a?(Net::SSH::Proxy::Command)
+          cmd << " -o ProxyCommand='#{config.ssh_proxy.command_line_template}'"
+        end
         cmd << " -t #{config.ssh_user}@#{host} '#{command.join(" ")}'"
       end
     end

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -211,6 +211,10 @@ class CommandsAppTest < ActiveSupport::TestCase
     assert_equal "ssh -J root@2.2.2.2 -t app@1.1.1.1 'ls'", new_command.run_over_ssh("ls", host: "1.1.1.1")
   end
 
+  test "run over ssh with proxy_command" do
+    @config[:ssh] = { "proxy_command" => "ssh -W %h:%p user@proxy-server" }
+    assert_equal "ssh -o ProxyCommand='ssh -W %h:%p user@proxy-server' -t root@1.1.1.1 'ls'", new_command.run_over_ssh("ls", host: "1.1.1.1")
+  end
 
   test "current_running_container_id" do
     assert_equal \


### PR DESCRIPTION
Fixes the Commands::Base's run_over_ssh function to support ssh proxy configuration with proxy_command.