### PR TITLE
Fix ssh symlink

### DIFF
--- a/test/integration/docker/deployer/Dockerfile
+++ b/test/integration/docker/deployer/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update --fix-missing && apt-get install -y docker-ce docker-ce-cli c
 COPY *.sh .
 COPY app/ .
 
+RUN rm -rf /root/.ssh
 RUN ln -s /shared/ssh /root/.ssh
 RUN mkdir -p /etc/docker/certs.d/registry:4443 && ln -s /shared/certs/domain.crt /etc/docker/certs.d/registry:4443/ca.crt
 

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -10,6 +10,13 @@ class IntegrationTest < ActiveSupport::TestCase
   end
 
   teardown do
+    unless passed?
+      [:deployer, :vm1, :vm2, :shared, :load_balancer].each do |container|
+        puts
+        puts "Logs for #{container}:"
+        docker_compose :logs, container
+      end
+    end
     docker_compose "down -t 1"
   end
 


### PR DESCRIPTION
Ensure the symlinks are created correctly whether or not /root/.ssh already exists.