### PR TITLE
Add a minimum version setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,16 @@ servers:
 
 That'll start the job containers with `docker run ... --cap-add --cpu-count 4 ...`.
 
+### Setting a minimum version
+
+You can set the minimum MRSK version with:
+
+```yaml
+minimum_version: 0.13.3
+```
+
+Note: versions <= 0.13.2 will ignore this setting.
+
 ### Configuring logging
 
 You can configure the logging driver and options passed to Docker using `logging`:

--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -165,8 +165,12 @@ class Mrsk::Configuration
     raw_config.readiness_delay || 7
   end
 
+  def minimum_version
+    raw_config.minimum_version
+  end
+
   def valid?
-    ensure_required_keys_present && ensure_env_available
+    ensure_required_keys_present && ensure_env_available && ensure_valid_mrsk_version
   end
 
 
@@ -228,6 +232,15 @@ class Mrsk::Configuration
 
       true
     end
+
+    def ensure_valid_mrsk_version
+      if minimum_version && Gem::Version.new(minimum_version) > Gem::Version.new(Mrsk::VERSION)
+        raise ArgumentError, "Current version is #{Mrsk::VERSION}, minimum required is #{minimum_version}"
+      end
+
+      true
+    end
+
 
     def role_names
       raw_config.servers.is_a?(Array) ? [ "web" ] : raw_config.servers.keys.sort

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -268,4 +268,20 @@ class ConfigurationTest < ActiveSupport::TestCase
   test "to_h" do
     assert_equal({ :roles=>["web"], :hosts=>["1.1.1.1", "1.1.1.2"], :primary_host=>"1.1.1.1", :version=>"missing", :repository=>"dhh/app", :absolute_image=>"dhh/app:missing", :service_with_version=>"app-missing", :env_args=>["-e", "REDIS_URL=\"redis://x/y\""], :ssh_options=>{:user=>"root", :auth_methods=>["publickey"]}, :volume_args=>["--volume", "/local/path:/container/path"], :logging=>["--log-opt", "max-size=\"10m\""], :healthcheck=>{"path"=>"/up", "port"=>3000, "max_attempts" => 7 }}, @config.to_h)
   end
+
+  test "min version is lower" do
+    config = Mrsk::Configuration.new(@deploy.tap { |c| c.merge!(minimum_version: "0.0.1") })
+    assert_equal "0.0.1", config.minimum_version
+  end
+
+  test "min version is equal" do
+    config = Mrsk::Configuration.new(@deploy.tap { |c| c.merge!(minimum_version: Mrsk::VERSION) })
+    assert_equal Mrsk::VERSION, config.minimum_version
+  end
+
+  test "min version is higher" do
+    assert_raises(ArgumentError) do
+      Mrsk::Configuration.new(@deploy.tap { |c| c.merge!(minimum_version: "10000.0.0") })
+    end
+  end
 end


### PR DESCRIPTION
Allow a minimum MRSK version to be specified in the config.