### PR TITLE
Ability to skip env argumentization for some CLI commands

### DIFF
--- a/lib/mrsk/cli/app.rb
+++ b/lib/mrsk/cli/app.rb
@@ -174,26 +174,30 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
 
     if options[:follow]
       run_locally do
-        info "Following logs on #{MRSK.primary_host}..."
+        MRSK.skip_argumentize_env do
+          info "Following logs on #{MRSK.primary_host}..."
 
-        MRSK.specific_roles ||= ["web"]
-        role = MRSK.roles_on(MRSK.primary_host).first
+          MRSK.specific_roles ||= ["web"]
+          role = MRSK.roles_on(MRSK.primary_host).first
 
-        info MRSK.app(role: role).follow_logs(host: MRSK.primary_host, grep: grep)
-        exec MRSK.app(role: role).follow_logs(host: MRSK.primary_host, grep: grep)
+          info MRSK.app(role: role).follow_logs(host: MRSK.primary_host, grep: grep)
+          exec MRSK.app(role: role).follow_logs(host: MRSK.primary_host, grep: grep)
+        end
       end
     else
       since = options[:since]
       lines = options[:lines].presence || ((since || grep) ? nil : 100) # Default to 100 lines if since or grep isn't set
 
-      on(MRSK.hosts) do |host|
-        roles = MRSK.roles_on(host)
+      MRSK.skip_argumentize_env do
+        on(MRSK.hosts) do |host|
+          roles = MRSK.roles_on(host)
 
-        roles.each do |role|
-          begin
-            puts_by_host host, capture_with_info(*MRSK.app(role: role).logs(since: since, lines: lines, grep: grep))
-          rescue SSHKit::Command::Failed
-            puts_by_host host, "Nothing found"
+          roles.each do |role|
+            begin
+              puts_by_host host, capture_with_info(*MRSK.app(role: role).logs(since: since, lines: lines, grep: grep))
+            rescue SSHKit::Command::Failed
+              puts_by_host host, "Nothing found"
+            end
           end
         end
       end

--- a/lib/mrsk/cli/healthcheck.rb
+++ b/lib/mrsk/cli/healthcheck.rb
@@ -4,8 +4,6 @@ class Mrsk::Cli::Healthcheck < Mrsk::Cli::Base
   desc "perform", "Health check current app version"
 
   def perform
-    MRSK.skip_argumentize_env!
-
     on(MRSK.primary_host) do
       begin
         execute *MRSK.healthcheck.run

--- a/lib/mrsk/cli/healthcheck.rb
+++ b/lib/mrsk/cli/healthcheck.rb
@@ -2,7 +2,10 @@ class Mrsk::Cli::Healthcheck < Mrsk::Cli::Base
   default_command :perform
 
   desc "perform", "Health check current app version"
+
   def perform
+    MRSK.skip_argumentize_env!
+
     on(MRSK.primary_host) do
       begin
         execute *MRSK.healthcheck.run

--- a/lib/mrsk/commander.rb
+++ b/lib/mrsk/commander.rb
@@ -27,6 +27,14 @@ class Mrsk::Commander
     self.specific_hosts = [ config.primary_web_host ]
   end
 
+  def skip_argumentize_env!
+    @skip_argumentize_env = true
+  end
+
+  def skip_argumentize_env?
+    !!@skip_argumentize_env
+  end
+
   def specific_roles=(role_names)
     @specific_roles = config.roles.select { |r| role_names.include?(r.name) } if role_names.present?
   end

--- a/lib/mrsk/commander.rb
+++ b/lib/mrsk/commander.rb
@@ -35,6 +35,14 @@ class Mrsk::Commander
     !!@skip_argumentize_env
   end
 
+  def skip_argumentize_env(&block)
+    @skip_argumentize_env = true
+
+    yield
+  ensure
+    @skip_argumentize_env = false
+  end
+
   def specific_roles=(role_names)
     @specific_roles = config.roles.select { |r| role_names.include?(r.name) } if role_names.present?
   end

--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -227,6 +227,8 @@ class Mrsk::Configuration
 
     # Will raise KeyError if any secret ENVs are missing
     def ensure_env_available
+      return true if MRSK.skip_argumentize_env?
+
       env_args
       roles.each(&:env_args)
 


### PR DESCRIPTION
Hey Team,

I already asked about this feature in Discussions: #306.
The problem is that when you run `mrsk` from your local development machine you always have to populate all secrets defined in `deploy.yml` (screenshot below).

<img width="717" alt="Screenshot 2023-06-19 at 20 49 47" src="https://github.com/mrsked/mrsk/assets/100725/62f5be94-d8c6-4de3-aabb-3fd4241d0b6b">

You can work around this problem by passing fake values to all required secrets. but this takes time and looks weird.
<img width="1494" alt="Screenshot 2023-06-19 at 20 52 57" src="https://github.com/mrsked/mrsk/assets/100725/ad7a32a9-864a-4138-ba4d-df01958da3e6">

This PR is work in progress and shows an idea how this can fixed. I added `Mrsk::Commander.skip_argumentize_env` method and updated `Mrsk::Configuration.ensure_env_available`.

The result is on a screenshot below.

<img width="1512" alt="Screenshot 2023-06-19 at 20 57 16" src="https://github.com/mrsked/mrsk/assets/100725/958bc5c8-beef-4663-938e-a6234ab474a9">

I want to hear your feedback. Is it something MRSK needs or not?
Thank you!
