### PR TITLE
Login to the registry proactively before stoping Accessory and Traefik

### DIFF
--- a/lib/mrsk/cli/traefik.rb
+++ b/lib/mrsk/cli/traefik.rb
@@ -19,10 +19,6 @@ class Mrsk::Cli::Traefik < Mrsk::Cli::Base
       stop
       remove_container
       boot(login: false)
-
-      on(MRSK.traefik_hosts) do
-        execute *MRSK.traefik.run, raise_on_non_zero_exit: false
-      end
     end
   end
 

--- a/lib/mrsk/cli/traefik.rb
+++ b/lib/mrsk/cli/traefik.rb
@@ -1,9 +1,9 @@
 class Mrsk::Cli::Traefik < Mrsk::Cli::Base
   desc "boot", "Boot Traefik on servers"
-  def boot
+  def boot(login: true)
     mutating do
       on(MRSK.traefik_hosts) do
-        execute *MRSK.registry.login
+        execute *MRSK.registry.login if login
         execute *MRSK.traefik.run, raise_on_non_zero_exit: false
       end
     end
@@ -12,9 +12,17 @@ class Mrsk::Cli::Traefik < Mrsk::Cli::Base
   desc "reboot", "Reboot Traefik on servers (stop container, remove container, start new container)"
   def reboot
     mutating do
+      on(MRSK.traefik_hosts) do
+        execute *MRSK.registry.login
+      end
+
       stop
       remove_container
-      boot
+      boot(login: false)
+
+      on(MRSK.traefik_hosts) do
+        execute *MRSK.traefik.run, raise_on_non_zero_exit: false
+      end
     end
   end
 

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -40,9 +40,10 @@ class CliAccessoryTest < CliTestCase
   end
 
   test "reboot" do
+    Mrsk::Commands::Registry.any_instance.expects(:login)
     Mrsk::Cli::Accessory.any_instance.expects(:stop).with("mysql")
     Mrsk::Cli::Accessory.any_instance.expects(:remove_container).with("mysql")
-    Mrsk::Cli::Accessory.any_instance.expects(:boot).with("mysql")
+    Mrsk::Cli::Accessory.any_instance.expects(:boot).with("mysql", login: false)
 
     run_command("reboot", "mysql")
   end

--- a/test/cli/traefik_test.rb
+++ b/test/cli/traefik_test.rb
@@ -9,9 +9,10 @@ class CliTraefikTest < CliTestCase
   end
 
   test "reboot" do
+    Mrsk::Commands::Registry.any_instance.expects(:login).twice
     Mrsk::Cli::Traefik.any_instance.expects(:stop)
     Mrsk::Cli::Traefik.any_instance.expects(:remove_container)
-    Mrsk::Cli::Traefik.any_instance.expects(:boot)
+    Mrsk::Cli::Traefik.any_instance.expects(:boot).with(login: false)
 
     run_command("reboot")
   end


### PR DESCRIPTION
Currently, `mrsk traefik reboot` and `mrsk accessory reboot` first do stop and only at the end of the script attempt to log in to the registry. If the login fails (e.g., due to an expired `MRSK_REGISTRY_PASSWORD`), Traefik or the accessory will remain stopped.

I have changed the order of commands performed during the reboot. Now, if the login fails, Traefik and the accessory will continue running.