### PR TITLE
feat: Add initial delay to healtchecks

### DIFF
--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -158,7 +158,7 @@ class Mrsk::Configuration
 
 
   def healthcheck
-    { "path" => "/up", "port" => 3000, "max_attempts" => 7 }.merge(raw_config.healthcheck || {})
+    { "path" => "/up", "port" => 3000, "max_attempts" => 7, "initial_delay" => 0 }.merge(raw_config.healthcheck || {})
   end
 
   def readiness_delay

--- a/lib/mrsk/utils/healthcheck_poller.rb
+++ b/lib/mrsk/utils/healthcheck_poller.rb
@@ -7,6 +7,12 @@ class Mrsk::Utils::HealthcheckPoller
     def wait_for_healthy(pause_after_ready: false, &block)
       attempt = 1
       max_attempts = MRSK.config.healthcheck["max_attempts"]
+      initial_delay = MRSK.config.healthcheck["initial_delay"]
+
+      if initial_delay > 0
+        info "Waiting #{initial_delay}s before checking container health..."
+        sleep initial_delay
+      end
 
       begin
         case status = block.call


### PR DESCRIPTION
Closes #361

Add config `intial_delay` option that would delay the healthcheck sequence

TODO:
- [ ] Specs
- [ ] Docs