### PR TITLE
Cleanup envify output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 coverage/*
 .DS_Store
 gemfiles/*.lock
+.idea/

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -174,7 +174,10 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
       env_path          = ".env"
     end
 
-    File.write(env_path, ERB.new(File.read(env_template_path)).result, perm: 0600)
+    output = ERB.new(File.read(env_template_path)).result
+    output = output.gsub(/\n{3,}/, "\n\n").gsub(/^(?![\r\n])\s+/, '')
+
+    File.write(env_path, output, perm: 0600)
   end
 
   desc "remove", "Remove Traefik, app, accessories, and registry session from servers"

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -332,6 +332,14 @@ class CliMainTest < CliTestCase
     run_command("envify")
   end
 
+  test "envify with bad formatting in ERB" do
+    # filters out more than 1 blank line + leading whitespace
+    File.expects(:read).with(".env.erb").returns("  HELLO=<%= 'world' %>\n HELLO2=<%= 'world2' %>\n\n\nBAR=foo")
+    File.expects(:write).with(".env", "HELLO=world\nHELLO2=world2\n\nBAR=foo", perm: 0600)
+
+    run_command("envify")
+  end
+
   test "envify with destination" do
     File.expects(:read).with(".env.staging.erb").returns("HELLO=<%= 'world' %>")
     File.expects(:write).with(".env.staging", "HELLO=world", perm: 0600)


### PR DESCRIPTION
Many editors (i.e. RubyMine) format erb with indents, causing `envify` to not output the nicest env files (output below, even though it technically works)

This PR resolves that by removing all leading whitespace + reming multiline newlines (if you have more than 1 blank line it's reduced to 1)

```erb
<% if 1 > 2 %>
  HELLO_WORLD=<%= op read ... <%>
<% end %>
```

outputs
```dotenv
  HELLO_WORLD=foobar
```