### PR TITLE
Include service name to lock details

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,7 +868,7 @@ If you wish to remove the entire application, including Traefik, containers, ima
 
 ## Locking
 
-Commands that are unsafe to run concurrently will take a deploy lock while they run. The lock is the `mrsk_lock` directory on the primary server.
+Commands that are unsafe to run concurrently will take a deploy lock while they run. The lock is the `mrsk_lock-<service>` directory on the primary server.
 
 You can check the lock status with:
 

--- a/lib/mrsk/commands/lock.rb
+++ b/lib/mrsk/commands/lock.rb
@@ -40,7 +40,7 @@ class Mrsk::Commands::Lock < Mrsk::Commands::Base
     end
 
     def lock_dir
-      :mrsk_lock
+      "mrsk_lock-#{config.service}"
     end
 
     def lock_details_file

--- a/test/cli/cli_test_case.rb
+++ b/test/cli/cli_test_case.rb
@@ -29,9 +29,9 @@ class CliTestCase < ActiveSupport::TestCase
 
     def stub_locking
       SSHKit::Backend::Abstract.any_instance.stubs(:execute)
-        .with { |arg1, arg2| arg1 == :mkdir && arg2 == :mrsk_lock }
+        .with { |arg1, arg2| arg1 == :mkdir && arg2 == "mrsk_lock-app" }
       SSHKit::Backend::Abstract.any_instance.stubs(:execute)
-        .with { |arg1, arg2| arg1 == :rm && arg2 == "mrsk_lock/details" }
+        .with { |arg1, arg2| arg1 == :rm && arg2 == "mrsk_lock-app/details" }
     end
 
     def assert_hook_ran(hook, output, version:, service_version:, hosts:, command:, subcommand: nil, runtime: nil)

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -63,11 +63,11 @@ class CliMainTest < CliTestCase
     Thread.report_on_exception = false
 
     SSHKit::Backend::Abstract.any_instance.stubs(:execute)
-      .with { |*arg| arg[0..1] == [:mkdir, :mrsk_lock] }
-      .raises(RuntimeError, "mkdir: cannot create directory ‘mrsk_lock’: File exists")
+      .with { |*arg| arg[0..1] == [:mkdir, 'mrsk_lock-app'] }
+      .raises(RuntimeError, "mkdir: cannot create directory ‘mrsk_lock-app’: File exists")
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_debug)
-      .with(:stat, :mrsk_lock, ">", "/dev/null", "&&", :cat, "mrsk_lock/details", "|", :base64, "-d")
+      .with(:stat, 'mrsk_lock-app', ">", "/dev/null", "&&", :cat, "mrsk_lock-app/details", "|", :base64, "-d")
 
     assert_raises(Mrsk::Cli::LockError) do
       run_command("deploy")
@@ -78,7 +78,7 @@ class CliMainTest < CliTestCase
     Thread.report_on_exception = false
 
     SSHKit::Backend::Abstract.any_instance.stubs(:execute)
-      .with { |*arg| arg[0..1] == [:mkdir, :mrsk_lock] }
+      .with { |*arg| arg[0..1] == [:mkdir, 'mrsk_lock-app'] }
       .raises(SocketError, "getaddrinfo: nodename nor servname provided, or not known")
 
     assert_raises(SSHKit::Runner::ExecuteError) do

--- a/test/commands/lock_test.rb
+++ b/test/commands/lock_test.rb
@@ -10,19 +10,19 @@ class CommandsLockTest < ActiveSupport::TestCase
 
   test "status" do
     assert_equal \
-      "stat mrsk_lock > /dev/null && cat mrsk_lock/details | base64 -d",
+      "stat mrsk_lock-app > /dev/null && cat mrsk_lock-app/details | base64 -d",
       new_command.status.join(" ")
   end
 
   test "acquire" do
     assert_match \
-      /mkdir mrsk_lock && echo ".*" > mrsk_lock\/details/m,
+      /mkdir mrsk_lock-app && echo ".*" > mrsk_lock-app\/details/m,
       new_command.acquire("Hello", "123").join(" ")
   end
 
   test "release" do
     assert_match \
-      "rm mrsk_lock/details && rm -r mrsk_lock",
+      "rm mrsk_lock-app/details && rm -r mrsk_lock-app",
       new_command.release.join(" ")
   end
 


### PR DESCRIPTION
Although the primary use case of MRSK is one app on a single host, some situations require us to deploy several apps on a single host (nobody wants to pay more if you can deploy a couple of apps to a single staging server).

Currently, MRSK creates a lock file that does not include service name information. This causes problems when deploying multiple apps at the same time. 

This PR adds a service name to the lock directory, so you can deploy multiple apps to the same host simultaneously without a problem. Hope you will find this useful too.