### PR TITLE
Support a --rolling option for traefik reboots

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,16 @@ traefik:
     entrypoints.otherentrypoint.address: ':9000'
 ```
 
+### Rebooting Traefik
+
+If you make changes to Traefik args or labels, you'll need to reboot with:
+
+`mrsk traefik reboot`
+
+In production, reboot the Traefik containers one by one with a slower but safer approach, using a rolling reboot:
+
+`mrsk traefik reboot --rolling`
+
 ### Configuring build args for new images
 
 Build arguments that aren't secret can also be configured:

--- a/lib/mrsk/cli/traefik.rb
+++ b/lib/mrsk/cli/traefik.rb
@@ -9,8 +9,8 @@ class Mrsk::Cli::Traefik < Mrsk::Cli::Base
     end
   end
 
-  method_option :rolling, type: :boolean, default: false, desc: "Reboot traefik on hosts in sequence, rather than in parallel"
   desc "reboot", "Reboot Traefik on servers (stop container, remove container, start new container)"
+  option :rolling, type: :boolean, default: false, desc: "Reboot traefik on hosts in sequence, rather than in parallel"
   def reboot
     mutating do
       on(MRSK.traefik_hosts, in: options[:rolling] ? :sequence : :parallel) do

--- a/lib/mrsk/cli/traefik.rb
+++ b/lib/mrsk/cli/traefik.rb
@@ -9,7 +9,7 @@ class Mrsk::Cli::Traefik < Mrsk::Cli::Base
     end
   end
 
-  method_option :rolling, type: :boolean, default: false
+  method_option :rolling, type: :boolean, default: false, desc: "Reboot traefik on hosts in sequence, rather than in parallel"
   desc "reboot", "Reboot Traefik on servers (stop container, remove container, start new container)"
   def reboot
     mutating do

--- a/test/cli/traefik_test.rb
+++ b/test/cli/traefik_test.rb
@@ -9,11 +9,18 @@ class CliTraefikTest < CliTestCase
   end
 
   test "reboot" do
-    Mrsk::Cli::Traefik.any_instance.expects(:stop)
-    Mrsk::Cli::Traefik.any_instance.expects(:remove_container)
-    Mrsk::Cli::Traefik.any_instance.expects(:boot)
+    run_command("reboot").tap do |output|
+      assert_match "docker container stop traefik", output
+      assert_match "docker container prune --force --filter label=org.opencontainers.image.title=Traefik", output
+      assert_match "docker login", output
+      assert_match "docker run --name traefik --detach --restart unless-stopped --publish 80:80 --volume /var/run/docker.sock:/var/run/docker.sock --log-opt max-size=\"10m\" #{Mrsk::Commands::Traefik::DEFAULT_IMAGE} --providers.docker --log.level=\"DEBUG\"", output
+    end
+  end
 
-    run_command("reboot")
+  test "reboot --rolling" do
+    run_command("reboot", "--rolling").tap do |output|
+      assert_match "Running docker container prune --force --filter label=org.opencontainers.image.title=Traefik on 1.1.1.1", output.lines[2]
+    end
   end
 
   test "start" do


### PR DESCRIPTION
Rolling restarts allow Traefik configuration changes without downtime with:

`mrsk traefik reboot --rolling`