### PR TITLE
WIP: Support for depot.dev builders

### DIFF
--- a/lib/mrsk/commands/builder.rb
+++ b/lib/mrsk/commands/builder.rb
@@ -7,6 +7,8 @@ class Mrsk::Commands::Builder < Mrsk::Commands::Base
 
   def target
     case
+    when config.builder.depot?
+      depot
     when !config.builder.multiarch? && !config.builder.cached?
       native
     when !config.builder.multiarch? && config.builder.cached?
@@ -18,6 +20,10 @@ class Mrsk::Commands::Builder < Mrsk::Commands::Base
     else
       multiarch
     end
+  end
+
+  def depot
+    @depot ||= Mrsk::Commands::Builder::Depot.new(config)
   end
 
   def native

--- a/lib/mrsk/commands/builder/depot.rb
+++ b/lib/mrsk/commands/builder/depot.rb
@@ -1,0 +1,38 @@
+class Mrsk::Commands::Builder::Depot < Mrsk::Commands::Builder::Base
+  def create
+    # No-op on native without cache
+  end
+
+  def remove
+    # No-op on native without cache
+  end
+
+  def push
+    depot :build,
+      "--push",
+      *platforms,
+      *build_options,
+      build_context
+  end
+
+  def info
+    # No-op on native
+  end
+
+  private
+    def depot(*args)
+      args.compact.unshift :depot
+    end
+
+    def platforms
+      if depot_options.is_a?(Hash) && !!depot_options["platforms"]
+        ["--platform", depot_options["platforms"].join(",")]
+      else
+        []
+      end
+    end
+
+    def depot_options
+      config.builder.depot_options
+    end
+end

--- a/lib/mrsk/configuration/builder.rb
+++ b/lib/mrsk/configuration/builder.rb
@@ -27,6 +27,10 @@ class Mrsk::Configuration::Builder
     !!@options["cache"]
   end
 
+  def depot?
+    !!@options["depot"]
+  end
+
   def args
     @options["args"] || {}
   end
@@ -57,6 +61,10 @@ class Mrsk::Configuration::Builder
 
   def remote_host
     @options["remote"]["host"] if remote?
+  end
+
+  def depot_options
+    @options["depot"]
   end
 
   def cache_from


### PR DESCRIPTION
This PR adds support for [Depot] (https://depot.dev/) builders.

This is a WIP PR to get feedback if the approach makes sense, and will refine this PR accordingly. This works 

## Examples:

1. Basic configuration. Builds for the same architecture as the local machine:

    ```yaml
    builder:
      depot: true
    ```

2. Specifying one or more platforms to build for:

    ```yaml
    builder:
      depot:
        platforms:
          - linux/amd64
          - linux/arm64
    ```