### PR TITLE
Log uncommitted changes during deploy

### DIFF
--- a/lib/mrsk/cli/build.rb
+++ b/lib/mrsk/cli/build.rb
@@ -18,7 +18,7 @@ class Mrsk::Cli::Build < Mrsk::Cli::Base
       run_hook "pre-build"
 
       if (uncommitted_changes = Mrsk::Utils.uncommitted_changes).present?
-        say "The following paths have uncommitted changes (check your .gitignore file):\n #{uncommitted_changes}", :yellow
+        say "The following paths have uncommitted changes:\n #{uncommitted_changes}", :yellow
       end
 
       run_locally do

--- a/lib/mrsk/cli/build.rb
+++ b/lib/mrsk/cli/build.rb
@@ -17,13 +17,13 @@ class Mrsk::Cli::Build < Mrsk::Cli::Base
       verify_local_dependencies
       run_hook "pre-build"
 
+      if (uncommitted_changes = Mrsk::Utils.uncommitted_changes).present?
+        say "The following paths have uncommitted changes (check your .gitignore file):\n #{uncommitted_changes}", :yellow
+      end
+
       run_locally do
         begin
           MRSK.with_verbosity(:debug) do
-            if (uncommitted_changes = Mrsk::Utils.uncommitted_changes).present?
-              say "The following paths have uncommitted changes (check your .gitignore file):\n #{uncommitted_changes}", :yellow
-            end
-
             execute *MRSK.builder.push
           end
         rescue SSHKit::Command::Failed => e

--- a/lib/mrsk/cli/build.rb
+++ b/lib/mrsk/cli/build.rb
@@ -19,7 +19,13 @@ class Mrsk::Cli::Build < Mrsk::Cli::Base
 
       run_locally do
         begin
-          MRSK.with_verbosity(:debug) { execute *MRSK.builder.push }
+          MRSK.with_verbosity(:debug) do
+            if (uncommitted_changes = Mrsk::Utils.uncommitted_changes).present?
+              say "The following paths have uncommitted changes (check your .gitignore file):\n #{uncommitted_changes}", :yellow
+            end
+
+            execute *MRSK.builder.push
+          end
         rescue SSHKit::Command::Failed => e
           if e.message =~ /(no builder)|(no such file or directory)/
             error "Missing compatible builder, so creating a new one first"

--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -262,7 +262,7 @@ class Mrsk::Configuration
     def git_version
       @git_version ||=
         if system("git rev-parse")
-          uncommitted_suffix = `git status --porcelain`.strip.present? ? "_uncommitted_#{SecureRandom.hex(8)}" : ""
+          uncommitted_suffix = Mrsk::Utils.uncommitted_changes.present? ? "_uncommitted_#{SecureRandom.hex(8)}" : ""
 
           "#{`git rev-parse HEAD`.strip}#{uncommitted_suffix}"
         else

--- a/lib/mrsk/utils.rb
+++ b/lib/mrsk/utils.rb
@@ -93,4 +93,8 @@ module Mrsk::Utils
       end
     end
   end
+
+  def uncommitted_changes
+    `git status --porcelain`.strip
+  end
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -92,7 +92,6 @@ class ConfigurationTest < ActiveSupport::TestCase
     ENV.delete("VERSION")
 
     @config.expects(:`).with("git rev-parse HEAD").returns("git-version")
-    # @config.expects(:`).with("git status --porcelain").returns("M   file\n")
     Mrsk::Utils.expects(:uncommitted_changes).returns("M   file\n")
     assert_match /^git-version_uncommitted_[0-9a-f]{16}$/, @config.version
   end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -84,7 +84,7 @@ class ConfigurationTest < ActiveSupport::TestCase
     ENV.delete("VERSION")
 
     @config.expects(:`).with("git rev-parse HEAD").returns("git-version")
-    @config.expects(:`).with("git status --porcelain").returns("")
+    Mrsk::Utils.expects(:uncommitted_changes).returns("")
     assert_equal "git-version", @config.version
   end
 
@@ -92,7 +92,8 @@ class ConfigurationTest < ActiveSupport::TestCase
     ENV.delete("VERSION")
 
     @config.expects(:`).with("git rev-parse HEAD").returns("git-version")
-    @config.expects(:`).with("git status --porcelain").returns("M   file\n")
+    # @config.expects(:`).with("git status --porcelain").returns("M   file\n")
+    Mrsk::Utils.expects(:uncommitted_changes).returns("M   file\n")
     assert_match /^git-version_uncommitted_[0-9a-f]{16}$/, @config.version
   end
 

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -61,4 +61,14 @@ class UtilsTest < ActiveSupport::TestCase
     assert_equal "\"https://example.com/\\$2\"",
       Mrsk::Utils.escape_shell_value("https://example.com/$2")
   end
+
+  test "uncommitted changes exist" do
+    Mrsk::Utils.expects(:`).with("git status --porcelain").returns("M   file\n")
+    assert_equal "M   file", Mrsk::Utils.uncommitted_changes
+  end
+
+  test "uncommitted changes do not exist" do
+    Mrsk::Utils.expects(:`).with("git status --porcelain").returns("")
+    assert_equal "", Mrsk::Utils.uncommitted_changes
+  end
 end


### PR DESCRIPTION
MRSK adds `uncommitted` suffix to the image name if there are any not committed files during deploy process. On the one side this is super helpful, when you deploy from your local host. On the other side this causes some problems during deploy from CD – you don't know what exactly changed during CD process (actions may leave some garbage after them). To find out what should be added to `.gitignore`, I usually add additional step to the job, which runs `git status --porcelain`.

Other users also have such questions: https://github.com/mrsked/mrsk/discussions/378.

This PR adds logging of uncommitted changes before `MRSK.builder.push` command.