### PR TITLE
Revert "Configurable SSH log levels"

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,15 +258,6 @@ ssh:
   proxy_command: aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p' --region=us-east-1 ## ssh via aws ssm
 ```
 
-### Configuring the SSH log level
-
-```yaml
-ssh:
-  log_level: debug
-```
-
-Valid levels are `debug`, `info`, `warn`, `error` and `fatal` (default).
-
 ### Using env variables
 
 You can inject env variables into the app containers using `env`:

--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -153,15 +153,7 @@ class Mrsk::Configuration
   end
 
   def ssh_options
-    { user: ssh_user, proxy: ssh_proxy, auth_methods: [ "publickey" ], logger: ssh_logger }.compact
-  end
-
-  def ssh_logger
-    @ssh_logger ||= ::Logger.new(STDERR).tap { |logger| logger.level = ssh_log_level }
-  end
-
-  def ssh_log_level
-    (raw_config.ssh && raw_config.ssh["log_level"]) || ::Logger::FATAL
+    { user: ssh_user, proxy: ssh_proxy, auth_methods: [ "publickey" ] }.compact
   end
 
 
@@ -193,8 +185,7 @@ class Mrsk::Configuration
       service_with_version: service_with_version,
       env_args: env_args,
       volume_args: volume_args,
-      ssh_options: ssh_options.except(:logger),
-      ssh_log_level: ssh_log_level,
+      ssh_options: ssh_options,
       builder: builder.to_h,
       accessories: raw_config.accessories,
       logging: logging_args,

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -211,21 +211,17 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal "root", @config.ssh_options[:user]
 
     config = Mrsk::Configuration.new(@deploy.tap { |c| c.merge!(ssh: { "user" => "app" }) })
-    assert_equal "app", config.ssh_options[:user]
-    assert_equal 4, config.ssh_options[:logger].level
-
-    config = Mrsk::Configuration.new(@deploy.tap { |c| c.merge!(ssh: { "log_level" => "debug" }) })
-    assert_equal 0, config.ssh_options[:logger].level
+    assert_equal "app", @config.ssh_options[:user]
   end
 
   test "ssh options with proxy host" do
     config = Mrsk::Configuration.new(@deploy.tap { |c| c.merge!(ssh: { "proxy" => "1.2.3.4" }) })
-    assert_equal "root@1.2.3.4", config.ssh_options[:proxy].jump_proxies
+    assert_equal "root@1.2.3.4", @config.ssh_options[:proxy].jump_proxies
   end
 
   test "ssh options with proxy host and user" do
     config = Mrsk::Configuration.new(@deploy.tap { |c| c.merge!(ssh: { "proxy" => "app@1.2.3.4" }) })
-    assert_equal "app@1.2.3.4", config.ssh_options[:proxy].jump_proxies
+    assert_equal "app@1.2.3.4", @config.ssh_options[:proxy].jump_proxies
   end
 
   test "volume_args" do
@@ -270,22 +266,7 @@ class ConfigurationTest < ActiveSupport::TestCase
   end
 
   test "to_h" do
-    assert_equal({
-      :roles=>["web"],
-      :hosts=>["1.1.1.1", "1.1.1.2"],
-      :primary_host=>"1.1.1.1",
-      :version=>"missing",
-      :repository=>"dhh/app",
-      :absolute_image=>"dhh/app:missing",
-      :service_with_version=>"app-missing",
-      :env_args=>["-e", "REDIS_URL=\"redis://x/y\""],
-      :ssh_options=>{:user=>"root", :auth_methods=>["publickey"]},
-      :ssh_log_level=>4,
-      :volume_args=>["--volume", "/local/path:/container/path"],
-      :builder=>{},
-      :logging=>["--log-opt", "max-size=\"10m\""],
-      :healthcheck=>{"path"=>"/up", "port"=>3000, "max_attempts" => 7 }
-    }, @config.to_h)
+    assert_equal({ :roles=>["web"], :hosts=>["1.1.1.1", "1.1.1.2"], :primary_host=>"1.1.1.1", :version=>"missing", :repository=>"dhh/app", :absolute_image=>"dhh/app:missing", :service_with_version=>"app-missing", :env_args=>["-e", "REDIS_URL=\"redis://x/y\""], :ssh_options=>{:user=>"root", :auth_methods=>["publickey"]}, :volume_args=>["--volume", "/local/path:/container/path"], :builder=>{}, :logging=>["--log-opt", "max-size=\"10m\""], :healthcheck=>{"path"=>"/up", "port"=>3000, "max_attempts" => 7 }}, @config.to_h)
   end
 
   test "min version is lower" do


### PR DESCRIPTION
SSHKit uses the ssh options as part of the connection cache key and the hash of a `Logger` is not stable. As a result this is breaking the SSHKit connection pool

Reverts mrsked/mrsk#386