### PR TITLE
Don't hide Traefik errors

### DIFF
--- a/lib/mrsk/cli/traefik.rb
+++ b/lib/mrsk/cli/traefik.rb
@@ -4,7 +4,7 @@ class Mrsk::Cli::Traefik < Mrsk::Cli::Base
     mutating do
       on(MRSK.traefik_hosts) do
         execute *MRSK.registry.login
-        execute *MRSK.traefik.run, raise_on_non_zero_exit: false
+        execute *MRSK.traefik.start_or_run
       end
     end
   end
@@ -16,9 +16,9 @@ class Mrsk::Cli::Traefik < Mrsk::Cli::Base
       on(MRSK.traefik_hosts, in: options[:rolling] ? :sequence : :parallel) do
         execute *MRSK.auditor.record("Rebooted traefik"), verbosity: :debug
         execute *MRSK.registry.login
-        execute *MRSK.traefik.stop, raise_on_non_zero_exit: false
+        execute *MRSK.traefik.stop
         execute *MRSK.traefik.remove_container
-        execute *MRSK.traefik.run, raise_on_non_zero_exit: false
+        execute *MRSK.traefik.run
       end
     end
   end
@@ -28,7 +28,7 @@ class Mrsk::Cli::Traefik < Mrsk::Cli::Base
     mutating do
       on(MRSK.traefik_hosts) do
         execute *MRSK.auditor.record("Started traefik"), verbosity: :debug
-        execute *MRSK.traefik.start, raise_on_non_zero_exit: false
+        execute *MRSK.traefik.start
       end
     end
   end
@@ -38,7 +38,7 @@ class Mrsk::Cli::Traefik < Mrsk::Cli::Base
     mutating do
       on(MRSK.traefik_hosts) do
         execute *MRSK.auditor.record("Stopped traefik"), verbosity: :debug
-        execute *MRSK.traefik.stop, raise_on_non_zero_exit: false
+        execute *MRSK.traefik.stop
       end
     end
   end

--- a/lib/mrsk/commands/traefik.rb
+++ b/lib/mrsk/commands/traefik.rb
@@ -30,6 +30,10 @@ class Mrsk::Commands::Traefik < Mrsk::Commands::Base
     docker :container, :stop, "traefik"
   end
 
+  def start_or_run
+    combine start, run, by: "||"
+  end
+
   def info
     docker :ps, "--filter", "name=^traefik$"
   end

--- a/test/integration/traefik_test.rb
+++ b/test/integration/traefik_test.rb
@@ -1,7 +1,21 @@
 require_relative "integration_test"
 
 class TraefikTest < IntegrationTest
-  test "boot, stop, start, restart, logs, remove" do
+  test "boot, reboot, stop, start, restart, logs, remove" do
+    mrsk :traefik, :boot
+    assert_traefik_running
+
+    mrsk :traefik, :reboot
+    assert_traefik_running
+
+    mrsk :traefik, :boot
+    assert_traefik_running
+
+    # Check booting when booted doesn't raise an error
+    mrsk :traefik, :stop
+    assert_traefik_not_running
+
+    # Check booting when stopped works
     mrsk :traefik, :boot
     assert_traefik_running
 


### PR DESCRIPTION
When stopping or starting Traefik, don't hide important errors.

Docker doesn't return an error when starting a started container or stopping a stopped container.

When rebooting we want to know about errors during run as we've just stopped and removed the previous container.

When booting, we want to leave the running container if it exists, restart a stopped container and run a new one if it doesn't.

We can implement this with `docker start ... || docker run ...`:
- if the container is started, `docker start` will exit with 0
- if the container is stopped, `docker start` will start and exit with 0
- if the container doesn't exist, `docker start` will return a non zero exit code and `docker run` will create a new container. Any errors in `docker run` will be returned